### PR TITLE
logic to ensre that claimant rep data is only shown on letter if sele…

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Helper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Helper.java
@@ -128,7 +128,7 @@ public class Helper {
         StringBuilder sb = new StringBuilder();
         RepresentedTypeC representedTypeC = caseData.getRepresentativeClaimantType();
         Optional<ClaimantIndType> claimantIndType = Optional.ofNullable(caseData.getClaimantIndType());
-        if (representedTypeC != null) {
+        if (representedTypeC != null && caseData.getClaimantRepresentedQuestion().equals("yes")) {
             sb.append("\"claimant_or_rep_full_name\":\"").append(nullCheck(representedTypeC.getNameOfRepresentative())).append(NEW_LINE);
             if (representedTypeC.getRepresentativeAddress()!= null) {
                 sb.append(getClaimantOrRepAddressUK(representedTypeC.getRepresentativeAddress()));

--- a/src/test/resources/caseDetailsScotTest1.json
+++ b/src/test/resources/caseDetailsScotTest1.json
@@ -11,7 +11,7 @@
     "tribunalCorrespondenceDX" : "1234567",
     "tribunalCorrespondenceEmail" : "GlasgowOfficeET@hmcts.gov.uk",
     "ethosCaseReference" : "123456",
-    "claimantRepresentedQuestion" : "no",
+    "claimantRepresentedQuestion" : "yes",
     "claimant_TypeOfClaimant" : "Individual",
     "addSubMultipleComment": "Comment",
     "additionalCaseInfo": {

--- a/src/test/resources/caseDetailsTest1.json
+++ b/src/test/resources/caseDetailsTest1.json
@@ -13,7 +13,7 @@
     "tribunalCorrespondenceEmail" : "ManchesterOfficeET@hmcts.gov.uk",
     "ethosCaseReference" : "123456",
     "leadClaimant" : "Yes",
-    "claimantRepresentedQuestion" : "no",
+    "claimantRepresentedQuestion" : "yes",
     "claimant_TypeOfClaimant" : "Individual",
     "preAcceptCase": {
       "caseAccepted": "Yes",

--- a/src/test/resources/caseDetailsTest4.json
+++ b/src/test/resources/caseDetailsTest4.json
@@ -12,7 +12,7 @@
     "tribunalCorrespondenceDX" : "123456",
     "tribunalCorrespondenceEmail" : "ManchesterOfficeET@hmcts.gov.uk",
     "ethosCaseReference" : "123456",
-    "claimantRepresentedQuestion" : "no",
+    "claimantRepresentedQuestion" : "yes",
     "claimant_TypeOfClaimant" : "Individual",
     "addSubMultipleComment": "Comment",
     "additionalCaseInfo": {

--- a/src/test/resources/caseDetailsTest5.json
+++ b/src/test/resources/caseDetailsTest5.json
@@ -12,7 +12,7 @@
     "tribunalCorrespondenceDX" : "123456",
     "tribunalCorrespondenceEmail" : "ManchesterOfficeET@hmcts.gov.uk",
     "ethosCaseReference" : "123456",
-    "claimantRepresentedQuestion" : "no",
+    "claimantRepresentedQuestion" : "yes",
     "claimant_TypeOfClaimant" : "Individual",
     "addSubMultipleComment": "Comment",
     "additionalCaseInfo": {

--- a/src/test/resources/caseDetailsTest6.json
+++ b/src/test/resources/caseDetailsTest6.json
@@ -12,7 +12,7 @@
     "tribunalCorrespondenceDX" : "123456",
     "tribunalCorrespondenceEmail" : "ManchesterOfficeET@hmcts.gov.uk",
     "ethosCaseReference" : "123456",
-    "claimantRepresentedQuestion" : "no",
+    "claimantRepresentedQuestion" : "yes",
     "claimant_TypeOfClaimant" : "Company",
     "claimant_Company" : "Orlando LTD",
     "addSubMultipleComment": "Comment",

--- a/src/test/resources/caseDetailsTest7.json
+++ b/src/test/resources/caseDetailsTest7.json
@@ -12,7 +12,7 @@
     "tribunalCorrespondenceDX" : "123456",
     "tribunalCorrespondenceEmail" : "ManchesterOfficeET@hmcts.gov.uk",
     "ethosCaseReference" : "123456",
-    "claimantRepresentedQuestion" : "no",
+    "claimantRepresentedQuestion" : "yes",
     "claimant_TypeOfClaimant" : "Individual",
     "addSubMultipleComment": "Comment",
     "additionalCaseInfo": {

--- a/src/test/resources/caseDetailsTest8.json
+++ b/src/test/resources/caseDetailsTest8.json
@@ -12,7 +12,7 @@
     "tribunalCorrespondenceDX" : "123456",
     "tribunalCorrespondenceEmail" : "ManchesterOfficeET@hmcts.gov.uk",
     "ethosCaseReference" : "123456",
-    "claimantRepresentedQuestion" : "no",
+    "claimantRepresentedQuestion" : "yes",
     "claimant_TypeOfClaimant" : "Individual",
     "addSubMultipleComment": "Comment",
     "additionalCaseInfo": {

--- a/src/test/resources/caseDetailsTest9.json
+++ b/src/test/resources/caseDetailsTest9.json
@@ -12,7 +12,7 @@
     "tribunalCorrespondenceDX" : "123456",
     "tribunalCorrespondenceEmail" : "ManchesterOfficeET@hmcts.gov.uk",
     "ethosCaseReference" : "123456",
-    "claimantRepresentedQuestion" : "no",
+    "claimantRepresentedQuestion" : "yes",
     "claimant_TypeOfClaimant" : "Individual",
     "addSubMultipleComment": "Comment",
     "additionalCaseInfo": {


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ERP-755

### Change description ###

Added logic to ensure that the claimant representative details are displayed within the generated letters only in the if the radio button asking for claimant representative is set to "yes".

**Does this PR introduce a breaking change?** (check one with "x")

[ ] Yes
[X] No

