### PR TITLE
respondent rep update code change reversed

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleBatchUpdate3Service.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleBatchUpdate3Service.java
@@ -54,10 +54,10 @@ public class MultipleBatchUpdate3Service {
 
             log.info("Sending updates to single cases with caseSearched");
 
-            if(respondentRepRemovalIsRequested(multipleData))
+            /*if(respondentRepRemovalIsRequested(multipleData))
             {
                 caseSearched.getCaseData().getRepCollection().clear();
-            }
+            }*/
 
             multipleHelperService.sendUpdatesToSinglesWithConfirmation(userToken, multipleDetails, errors,
                     multipleObjects, caseSearched.getCaseData());
@@ -70,14 +70,14 @@ public class MultipleBatchUpdate3Service {
         }
 
     }
-
+/*
     private boolean respondentRepRemovalIsRequested(MultipleData multipleData)
     {
         return multipleData != null &&
                (multipleData.getBatchRemoveRespondentRep() != null &&
                     multipleData.getBatchRemoveRespondentRep().equals(YES));
     }
-
+*/
     private boolean checkAnyChange(MultipleData multipleData) {
 
         return (


### PR DESCRIPTION
Code change for batch respondent rep update is reversed temporarily to check if the existing behaviour still works correctly.


https://tools.hmcts.net/jira/browse/ECM-24


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
