### PR TITLE
ecm-common reference update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,7 +196,7 @@ dependencies {
 
 
 
-    implementation 'com.github.hmcts:ecm-common:0.1.91'
+    implementation 'com.github.hmcts:ecm-common:0.1.93'
 
 // For pdfbox and elasticsearch CVEs
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.24'


### PR DESCRIPTION
The ecm-common reference is updated from 0.1.92 to 0.1.93.

Also, code that was commented out is removed.

Comments added for the three types of batch updates based on the config file values.


This is partial code change for https://tools.hmcts.net/jira/browse/ECM-24.




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
