### PR TITLE
ecm-common upgrade to version 0.1.94

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,9 +194,7 @@ dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
-
-
-    implementation 'com.github.hmcts:ecm-common:0.1.93'
+    implementation 'com.github.hmcts:ecm-common:0.1.94'
 
 // For pdfbox and elasticsearch CVEs
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.24'


### PR DESCRIPTION
The reference to ecm-common lib is upgrade to version 0.1.94.

https://tools.hmcts.net/jira/browse/ECM-24

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
