### PR TITLE
Handle representative claimant type object with no values set

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ExcelActionsController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ExcelActionsController.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -15,24 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.ecm.common.helpers.UtilHelper;
 import uk.gov.hmcts.ecm.common.model.ccd.CCDCallbackResponse;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleCallbackResponse;
-import uk.gov.hmcts.ecm.common.model.multiples.MultipleDetails;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleRequest;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.MultiplesHelper;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.EventValidationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleAmendService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleCreationMidEventValidationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleCreationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleDynamicListFlagsService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleHelperService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleMidEventValidationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultiplePreAcceptService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleSingleMidEventValidationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleUpdateService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleUploadService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.SubMultipleMidEventValidationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.SubMultipleUpdateService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleTransferService;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -406,19 +391,7 @@ public class ExcelActionsController {
 
         multipleSingleMidEventValidationService.multipleSingleValidationLogic(userToken, multipleDetails, errors);
 
-        logJson(multipleDetails);
-
         return getMultipleCallbackRespEntity(errors, multipleDetails);
-    }
-
-    private void logJson(MultipleDetails multipleDetails) {
-        try {
-            var objectMapper = new ObjectMapper();
-            var json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(multipleDetails);
-            log.info(json);
-        } catch (JsonProcessingException e) {
-            log.error("Unexpected error logging json", e);
-        }
     }
 
     @PostMapping(value = "/multipleMidBatch1Validation", consumes = APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleSingleMidEventValidationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleSingleMidEventValidationService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ecm.common.model.bulk.types.DynamicFixedListType;
 import uk.gov.hmcts.ecm.common.model.bulk.types.DynamicValueType;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SELECT_NONE_VALUE;
+
+import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleData;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.Helper;
@@ -108,7 +110,7 @@ public class MultipleSingleMidEventValidationService {
 
         List<DynamicValueType> claimantDynamicList = new ArrayList<>();
 
-        if (submitEvent.getCaseData().getRepresentativeClaimantType() != null) {
+        if (hasRepresentativeClaimant(submitEvent.getCaseData())) {
 
             claimantDynamicList = new ArrayList<>(Collections.singletonList(
                     Helper.getDynamicValue(
@@ -185,6 +187,11 @@ public class MultipleSingleMidEventValidationService {
 
         multipleData.setBatchUpdateRespondentRep(populateDynamicList(repCollection));
 
+    }
+
+    private boolean hasRepresentativeClaimant(CaseData caseData) {
+        var representativeClaimantType = caseData.getRepresentativeClaimantType();
+        return representativeClaimantType != null && representativeClaimantType.getNameOfRepresentative() != null;
     }
 
     private DynamicFixedListType populateDynamicList(List<DynamicValueType> listItems) {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleSingleMidEventValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleSingleMidEventValidationServiceTest.java
@@ -167,4 +167,44 @@ public class MultipleSingleMidEventValidationServiceTest {
 
     }
 
+    /**
+     * This test is for the scenario where CCD returns the case data with a
+     * representativeClaimantType as a RepresentedTypeC object with no values set
+     */
+    @Test
+    public void shouldHandleRepresentativeClaimantWithNoValues() {
+        multipleDetails.getCaseData().setBatchUpdateCase("245000/2020");
+
+        RepresentedTypeC representedTypeC = new RepresentedTypeC();
+        submitEventList.get(0).getCaseData().setRepresentativeClaimantType(representedTypeC);
+
+        JurCodesTypeItem jurCodesTypeItem = new JurCodesTypeItem();
+        JurCodesType jurCodesType = new JurCodesType();
+        jurCodesType.setJuridictionCodesList("AA");
+        jurCodesTypeItem.setValue(jurCodesType);
+        submitEventList.get(0).getCaseData().setJurCodesCollection(new ArrayList<>(Collections.singletonList(jurCodesTypeItem)));
+
+        when(singleCasesReadingService.retrieveSingleCase(userToken,
+                multipleDetails.getCaseTypeId(),
+                multipleDetails.getCaseData().getBatchUpdateCase(),
+                multipleDetails.getCaseData().getMultipleSource()))
+                .thenReturn(submitEventList.get(0));
+
+        when(multipleHelperService.getEthosCaseRefCollection(userToken,
+                multipleDetails.getCaseData(),
+                errors))
+                .thenReturn(caseIdCollection);
+
+        multipleSingleMidEventValidationService.multipleSingleValidationLogic(
+                userToken,
+                multipleDetails,
+                errors);
+
+        assertEquals(0, errors.size());
+        assertEquals(1, multipleDetails.getCaseData().getBatchUpdateClaimantRep().getListItems().size());
+        assertEquals(2, multipleDetails.getCaseData().getBatchUpdateJurisdiction().getListItems().size());
+        assertEquals(2, multipleDetails.getCaseData().getBatchUpdateRespondent().getListItems().size());
+        assertEquals(2, multipleDetails.getCaseData().getBatchUpdateRespondentRep().getListItems().size());
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ECM-225


### Change description ###
If no claimant representative is set then CCD is setting it to an object with no values. This causes Batch Update mid-even validation to fail. Therefore need to ensure a claimant representative does actually exist before adding it as a dynamic list entry for batch update


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
