### PR TITLE
ecm-common reference version upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
-    implementation 'com.github.hmcts:ecm-common:0.1.94'
+    implementation 'com.github.hmcts:ecm-common:0.1.95'
 
 // For pdfbox and elasticsearch CVEs
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.24'


### PR DESCRIPTION
An ecm-common reference version is upgraded to 1.0.95.

https://tools.hmcts.net/jira/browse/ECM-24


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
