### PR TITLE
multiple case reference link is removed

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/AddSingleCaseToMultipleService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/AddSingleCaseToMultipleService.java
@@ -37,7 +37,6 @@ public class AddSingleCaseToMultipleService {
 
             String leadClaimant = caseData.getLeadClaimant();
             String updatedMultipleReference = caseData.getMultipleReference();
-
             String multipleCaseTypeId = UtilHelper.getBulkCaseTypeId(caseTypeId);
 
             log.info("Pulling the multiple case: " + updatedMultipleReference);
@@ -87,12 +86,12 @@ public class AddSingleCaseToMultipleService {
     }
 
     private void updateCaseDataForMultiple(CaseData caseData, String newMultipleReference, String leadClaimant,
-                                           Long multipleCaseId) {
+                                           long multipleCaseId) {
         caseData.setMultipleReference(newMultipleReference);
         caseData.setCaseType(MULTIPLE_CASE_TYPE);
         log.info("setLeadClaimant is set to " + leadClaimant);
         caseData.setLeadClaimant(leadClaimant);
-        caseData.setMultipleReferenceLink(multipleCaseId.toString());
+        caseData.setMultipleReferenceLink(String.valueOf(multipleCaseId));
     }
 
     private void addNewLeadToMultiple(String userToken, String multipleCaseTypeId, String jurisdiction,

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/AddSingleCaseToMultipleService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/AddSingleCaseToMultipleService.java
@@ -73,8 +73,8 @@ public class AddSingleCaseToMultipleService {
                     multipleData, new ArrayList<>(Collections.singletonList(newEthosCaseReferenceToAdd)), errors);
 
             log.info("Update multipleRef, multiple and lead");
-
-            updateCaseDataForMultiple(caseData, updatedMultipleReference, leadClaimant);
+            var multipleCaseId = multipleEvent.getCaseId();
+            updateCaseDataForMultiple(caseData, updatedMultipleReference, leadClaimant, multipleCaseId);
 
             log.info("Reset mid fields");
 
@@ -86,19 +86,13 @@ public class AddSingleCaseToMultipleService {
         }
     }
 
-    private String createMultipleReferenceLink(CaseData caseData) {
-        var url =  "<a href=\"../cases/case-details/" + caseData.getMultipleReference() + "\">" +
-                caseData.getMultipleReference() + "</a>";
-        log.info("setMultipleReferenceLink is set to " + url);
-        return url;
-    }
-
-    private void updateCaseDataForMultiple(CaseData caseData, String newMultipleReference, String leadClaimant) {
+    private void updateCaseDataForMultiple(CaseData caseData, String newMultipleReference, String leadClaimant,
+                                           Long multipleCaseId) {
         caseData.setMultipleReference(newMultipleReference);
         caseData.setCaseType(MULTIPLE_CASE_TYPE);
         log.info("setLeadClaimant is set to " + leadClaimant);
         caseData.setLeadClaimant(leadClaimant);
-        caseData.setMultipleReferenceLink(createMultipleReferenceLink(caseData));
+        caseData.setMultipleReferenceLink(multipleCaseId.toString());
     }
 
     private void addNewLeadToMultiple(String userToken, String multipleCaseTypeId, String jurisdiction,

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/AddSingleCaseToMultipleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/AddSingleCaseToMultipleServiceTest.java
@@ -39,7 +39,7 @@ public class AddSingleCaseToMultipleServiceTest {
     private MultipleDetails multipleDetails;
     private List<SubmitMultipleEvent> submitMultipleEvents;
     private List<String> caseIdCollection;
-    private String multipleRefLink;
+    //private String multipleRefLink;
 
     @Before
     public void setUp() {
@@ -55,7 +55,7 @@ public class AddSingleCaseToMultipleServiceTest {
         submitMultipleEvents = MultipleUtil.getSubmitMultipleEvents();
         caseIdCollection = new ArrayList<>(Arrays.asList("21006/2020", "245000/2020", "245001/2020"));
         userToken = "authString";
-        multipleRefLink = "<a href=\"../cases/case-details/246000" + "\">" + "246000" + "</a>";
+        //multipleRefLink = "<a href=\"../cases/case-details/246000" + "\">" + "246000" + "</a>";
     }
 
     @Test
@@ -115,7 +115,8 @@ public class AddSingleCaseToMultipleServiceTest {
         assertEquals(MULTIPLE_CASE_TYPE, caseDetails.getCaseData().getCaseType());
         assertEquals("246000", caseDetails.getCaseData().getMultipleReference());
         assertEquals(YES, caseDetails.getCaseData().getLeadClaimant());
-        assertEquals(multipleRefLink, caseDetails.getCaseData().getMultipleReferenceLink());
+        var expected = String.valueOf(submitMultipleEvents.get(0).getCaseId());
+        assertEquals(expected, caseDetails.getCaseData().getMultipleReferenceLink());
 
     }
 
@@ -164,7 +165,8 @@ public class AddSingleCaseToMultipleServiceTest {
         assertEquals(MULTIPLE_CASE_TYPE, caseDetails.getCaseData().getCaseType());
         assertEquals("246000", caseDetails.getCaseData().getMultipleReference());
         assertEquals(NO, caseDetails.getCaseData().getLeadClaimant());
-        assertEquals(multipleRefLink, caseDetails.getCaseData().getMultipleReferenceLink());
+        var expected = String.valueOf(submitMultipleEvents.get(0).getCaseId());
+        assertEquals(expected, caseDetails.getCaseData().getMultipleReferenceLink());
 
     }
 
@@ -222,7 +224,8 @@ public class AddSingleCaseToMultipleServiceTest {
         assertEquals(MULTIPLE_CASE_TYPE, caseDetails.getCaseData().getCaseType());
         assertEquals("246000", caseDetails.getCaseData().getMultipleReference());
         assertEquals(YES, caseDetails.getCaseData().getLeadClaimant());
-        assertEquals(multipleRefLink, caseDetails.getCaseData().getMultipleReferenceLink());
+        var expected = String.valueOf(submitMultipleEvents.get(0).getCaseId());
+        assertEquals(expected, caseDetails.getCaseData().getMultipleReferenceLink());
 
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/AddSingleCaseToMultipleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/AddSingleCaseToMultipleServiceTest.java
@@ -39,7 +39,6 @@ public class AddSingleCaseToMultipleServiceTest {
     private MultipleDetails multipleDetails;
     private List<SubmitMultipleEvent> submitMultipleEvents;
     private List<String> caseIdCollection;
-    //private String multipleRefLink;
 
     @Before
     public void setUp() {
@@ -55,7 +54,6 @@ public class AddSingleCaseToMultipleServiceTest {
         submitMultipleEvents = MultipleUtil.getSubmitMultipleEvents();
         caseIdCollection = new ArrayList<>(Arrays.asList("21006/2020", "245000/2020", "245001/2020"));
         userToken = "authString";
-        //multipleRefLink = "<a href=\"../cases/case-details/246000" + "\">" + "246000" + "</a>";
     }
 
     @Test


### PR DESCRIPTION
Multiple reference link is removed. Also, multiple case id it set to the single case field(i.e MultipleReferenceLink) for reference link url construction.  

https://tools.hmcts.net/jira/browse/ECM-198


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
