### PR TITLE
Prevent properties not in CCD config from being included in callback …

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/casesawaitingjudgment/CasesAwaitingJudgmentReportData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/casesawaitingjudgment/CasesAwaitingJudgmentReportData.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.reports.casesawaitingjudgment;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import uk.gov.hmcts.ecm.common.model.listing.ListingData;
 
@@ -8,8 +9,14 @@ import java.util.List;
 
 @Getter
 public class CasesAwaitingJudgmentReportData extends ListingData {
+    // JsonIgnore is required on properties so that the report data is not
+    // returned to CCD in any callback response.
+    // Otherwise this would trigger a CCD Case Data Validation error
+    // because the properties are not in the CCD config
 
+    @JsonIgnore
     private final ReportSummary reportSummary;
+    @JsonIgnore
     private final List<ReportDetail> reportDetails = new ArrayList<>();
 
     public CasesAwaitingJudgmentReportData(ReportSummary reportSummary) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ECM-139


### Change description ###
Report data is not part of the CCD config and so needs to be excluded from the JSON in the callback response data otherwise a CCD case data validation error is created


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
