### PR TITLE
ECM-324 implemented

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/DocumentHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/DocumentHelper.java
@@ -241,7 +241,7 @@ public class DocumentHelper {
         List<RepresentedTypeRItem> representedTypeRList = caseData.getRepCollection();
         List<RespondentSumTypeItem> respondentSumTypeItemList = !CollectionUtils.isEmpty(caseData.getRespondentCollection())
                 && !CollectionUtils.isEmpty(caseData.getRepCollection()) ? caseData.getRespondentCollection().stream()
-                .filter(a-> a.getValue().getRespondentName()
+                .filter(a-> (Strings.isNullOrEmpty(a.getValue().getResponseContinue()) || YES.equals(a.getValue().getResponseContinue())) && a.getValue().getRespondentName()
                         .equals(caseData.getRepCollection().get(0).getValue().getRespRepName())).collect(Collectors.toList()): new ArrayList<>();
         boolean responseNotStruckOut = CollectionUtils.isEmpty(respondentSumTypeItemList)
                 || Strings.isNullOrEmpty(respondentSumTypeItemList.get(0).getValue().getResponseStruckOut())


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ECM-324

### Change description ###
In a case where the claim is no longer continuing against a Respondent, the R's and their rep's details should not appear on letters


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
