### PR TITLE
Update log4J version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,10 +205,12 @@ def versions = [
         pact_version    : '4.1.7'
 ]
 
+ext {
+    log4JVersion = '2.15.0'
+}
+
 dependencies {
-
-    implementation 'com.github.hmcts:ecm-common:0.1.158'
-
+    implementation 'com.github.hmcts:ecm-common:0.1.160'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -224,7 +226,8 @@ dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.21'
-
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.48'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.48'
 


### PR DESCRIPTION
### Change description ###
There is a critical vulnerability in all versions of log4j and log4j2.
Please upgrade to log4j 2.15.0.

https://www.lunasec.io/docs/blog/log4j-zero-day/
https://arstechnica.com/information-technology/2021/12/minecraft-and-other-apps-face-serious-threat-from-new-code-execution-bug/


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
