### PR TITLE
hearing break and resume auto populate removed

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -215,12 +215,9 @@ public class CaseManagementForCaseWorkerService {
                             : hearingTypeItem.getValue().getHearingDateCollection()) {
                         var dateListedType = dateListedTypeItem.getValue();
                         if (dateListedType.getHearingStatus() == null) {
-                            var listedDateWithZeroTime = dateListedType.getListedDate().split("T")[0] + "T00:00:00";
                             dateListedType.setHearingStatus(HEARING_STATUS_LISTED);
                             dateListedType.setHearingTimingStart(dateListedType.getListedDate());
-                            dateListedType.setHearingTimingBreak(listedDateWithZeroTime);
-                            dateListedType.setHearingTimingResume(listedDateWithZeroTime);
-                            dateListedType.setHearingTimingFinish(listedDateWithZeroTime);
+                            dateListedType.setHearingTimingFinish(dateListedType.getListedDate());
                         }
                         populateHearingVenueFromHearingLevelToDayLevel(dateListedType, hearingType, caseTypeId);
                     }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -432,12 +432,8 @@ public class CaseManagementForCaseWorkerServiceTest {
                 .getHearingDateCollection().get(0).getValue().getHearingVenueDay());
         assertEquals("2019-11-01T12:11:00.000", caseData.getHearingCollection().get(0).getValue()
                 .getHearingDateCollection().get(0).getValue().getHearingTimingStart());
-        assertEquals("2019-11-01T00:00:00", caseData.getHearingCollection().get(0).getValue()
+        assertEquals("2019-11-01T12:11:00.000", caseData.getHearingCollection().get(0).getValue()
                 .getHearingDateCollection().get(0).getValue().getHearingTimingFinish());
-        assertEquals("2019-11-01T00:00:00", caseData.getHearingCollection().get(0).getValue()
-                .getHearingDateCollection().get(0).getValue().getHearingTimingResume());
-        assertEquals("2019-11-01T00:00:00", caseData.getHearingCollection().get(0).getValue()
-                .getHearingDateCollection().get(0).getValue().getHearingTimingBreak());
     }
 
     @Test


### PR DESCRIPTION
Hearing break and resume times auto populate removed. Also, hearing finish time is changed to default to start time. An affected unit test is updated too.

https://tools.hmcts.net/jira/browse/ECM-579


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
