### PR TITLE
Ecm 97 date parser fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/memberdays/MemberDaysReport.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/memberdays/MemberDaysReport.java
@@ -163,12 +163,12 @@ public class MemberDaysReport {
             && dateListedTypeItem.getValue().getHearingTimingFinish() != null) {
 
             var currentHearingTimingStart = dateListedTypeItem.getValue().getHearingTimingStart();
-            var hearingStart = currentHearingTimingStart.contains(".000")
+            var hearingStart = currentHearingTimingStart.endsWith(".000")
                 ? LocalDateTime.parse(currentHearingTimingStart, OLD_DATE_TIME_PATTERN)
                 : LocalDateTime.parse(currentHearingTimingStart, OLD_DATE_TIME_PATTERN3);
 
             var currentHearingTimingFinish = dateListedTypeItem.getValue().getHearingTimingFinish();
-            var hearingFinish = currentHearingTimingFinish.contains(".000")
+            var hearingFinish = currentHearingTimingFinish.endsWith(".000")
                 ? LocalDateTime.parse(currentHearingTimingFinish, OLD_DATE_TIME_PATTERN)
                 : LocalDateTime.parse(currentHearingTimingFinish, OLD_DATE_TIME_PATTERN3);
 
@@ -179,11 +179,11 @@ public class MemberDaysReport {
         if (dateListedTypeItem.getValue().getHearingTimingBreak() != null
             && dateListedTypeItem.getValue().getHearingTimingResume() != null) {
             var hearingBreakStart = dateListedTypeItem.getValue().getHearingTimingBreak();
-            var hearingBreak = hearingBreakStart.contains(".000")
+            var hearingBreak = hearingBreakStart.endsWith(".000")
                 ? LocalDateTime.parse(hearingBreakStart, OLD_DATE_TIME_PATTERN)
                 : LocalDateTime.parse(hearingBreakStart, OLD_DATE_TIME_PATTERN3);
             var hearingBreakEnd = dateListedTypeItem.getValue().getHearingTimingResume();
-            var hearingResume = hearingBreakEnd.contains(".000")
+            var hearingResume = hearingBreakEnd.endsWith(".000")
                 ? LocalDateTime.parse(hearingBreakEnd, OLD_DATE_TIME_PATTERN)
                 : LocalDateTime.parse(hearingBreakEnd, OLD_DATE_TIME_PATTERN3);
             breakResumeDuration = Duration.between(hearingBreak, hearingResume).toMinutes();

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/memberdays/MemberDaysReport.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/memberdays/MemberDaysReport.java
@@ -162,36 +162,32 @@ public class MemberDaysReport {
         if (dateListedTypeItem.getValue().getHearingTimingStart() != null
             && dateListedTypeItem.getValue().getHearingTimingFinish() != null) {
 
-            var currentHearingTimingStart = dateListedTypeItem.getValue().getHearingTimingStart();
-            var hearingStart = currentHearingTimingStart.endsWith(".000")
-                ? LocalDateTime.parse(currentHearingTimingStart, OLD_DATE_TIME_PATTERN)
-                : LocalDateTime.parse(currentHearingTimingStart, OLD_DATE_TIME_PATTERN3);
-
-            var currentHearingTimingFinish = dateListedTypeItem.getValue().getHearingTimingFinish();
-            var hearingFinish = currentHearingTimingFinish.endsWith(".000")
-                ? LocalDateTime.parse(currentHearingTimingFinish, OLD_DATE_TIME_PATTERN)
-                : LocalDateTime.parse(currentHearingTimingFinish, OLD_DATE_TIME_PATTERN3);
-
+            var hearingStart = convertHearingTime(
+                dateListedTypeItem.getValue().getHearingTimingStart());
+            var hearingFinish = convertHearingTime(
+                dateListedTypeItem.getValue().getHearingTimingFinish());
             startFinishDuration = Duration.between(hearingStart, hearingFinish).toMinutes();
         }
 
         long breakResumeDuration = 0;
         if (dateListedTypeItem.getValue().getHearingTimingBreak() != null
             && dateListedTypeItem.getValue().getHearingTimingResume() != null) {
-            var hearingBreakStart = dateListedTypeItem.getValue().getHearingTimingBreak();
-            var hearingBreak = hearingBreakStart.endsWith(".000")
-                ? LocalDateTime.parse(hearingBreakStart, OLD_DATE_TIME_PATTERN)
-                : LocalDateTime.parse(hearingBreakStart, OLD_DATE_TIME_PATTERN3);
-            var hearingBreakEnd = dateListedTypeItem.getValue().getHearingTimingResume();
-            var hearingResume = hearingBreakEnd.endsWith(".000")
-                ? LocalDateTime.parse(hearingBreakEnd, OLD_DATE_TIME_PATTERN)
-                : LocalDateTime.parse(hearingBreakEnd, OLD_DATE_TIME_PATTERN3);
+            var hearingBreak = convertHearingTime(
+                dateListedTypeItem.getValue().getHearingTimingBreak());
+            var hearingResume = convertHearingTime(
+                dateListedTypeItem.getValue().getHearingTimingResume());
             breakResumeDuration = Duration.between(hearingBreak, hearingResume).toMinutes();
         }
 
         var duration = Math.abs(startFinishDuration - breakResumeDuration);
 
         return String.valueOf(duration);
+    }
+
+    private LocalDateTime convertHearingTime(String dateToConvert) {
+        return dateToConvert.endsWith(".000")
+            ? LocalDateTime.parse(dateToConvert, OLD_DATE_TIME_PATTERN)
+            : LocalDateTime.parse(dateToConvert, OLD_DATE_TIME_PATTERN3);
     }
 
     private List<HearingTypeItem> getValidHearings(CaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/memberdays/MemberDaysReport.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/memberdays/MemberDaysReport.java
@@ -178,10 +178,14 @@ public class MemberDaysReport {
         long breakResumeDuration = 0;
         if (dateListedTypeItem.getValue().getHearingTimingBreak() != null
             && dateListedTypeItem.getValue().getHearingTimingResume() != null) {
-            var hearingBreak = LocalDateTime.parse(dateListedTypeItem.getValue().getHearingTimingBreak(),
-                OLD_DATE_TIME_PATTERN3);
-            var hearingResume = LocalDateTime.parse(dateListedTypeItem.getValue().getHearingTimingResume(),
-                OLD_DATE_TIME_PATTERN3);
+            var hearingBreakStart = dateListedTypeItem.getValue().getHearingTimingBreak();
+            var hearingBreak = hearingBreakStart.contains(".000")
+                ? LocalDateTime.parse(hearingBreakStart, OLD_DATE_TIME_PATTERN)
+                : LocalDateTime.parse(hearingBreakStart, OLD_DATE_TIME_PATTERN3);
+            var hearingBreakEnd = dateListedTypeItem.getValue().getHearingTimingResume();
+            var hearingResume = hearingBreakEnd.contains(".000")
+                ? LocalDateTime.parse(hearingBreakEnd, OLD_DATE_TIME_PATTERN)
+                : LocalDateTime.parse(hearingBreakEnd, OLD_DATE_TIME_PATTERN3);
             breakResumeDuration = Duration.between(hearingBreak, hearingResume).toMinutes();
         }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/memberdays/MemberDaysReportTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/memberdays/MemberDaysReportTest.java
@@ -355,6 +355,59 @@ public class MemberDaysReportTest {
     }
 
     @Test
+    public void shouldParseCorrectHearingDurationForDateWithMilliseconds() {
+        var memberDaysReport = new MemberDaysReport();
+        var thirdCase = submitEvents.get(2);
+        var hearingWithInvalidDate = thirdCase.getCaseData().getHearingCollection().get(0);
+
+        var dateListedTypeItem6 = new DateListedTypeItem();
+        var dateListedType6 = new DateListedType();
+        dateListedType6.setHearingStatus(HEARING_STATUS_HEARD);
+        dateListedType6.setHearingClerk("Clerk test");
+        dateListedType6.setHearingRoomGlasgow("Tribunal 66");
+        dateListedType6.setHearingAberdeen("AberdeenVenue26");
+        dateListedType6.setHearingVenueDay("Aberdeen6");
+        dateListedType6.setListedDate("2019-12-29T12:11:55.000");
+        dateListedType6.setHearingTimingStart("2019-12-29T13:11:55.000");
+        dateListedType6.setHearingTimingBreak("2019-12-29T15:11:55.000");
+        dateListedType6.setHearingTimingResume("2019-12-29T15:30:55.000");
+        dateListedType6.setHearingTimingFinish("2019-12-29T19:30:55.000");
+        dateListedTypeItem6.setId("3456");
+        dateListedTypeItem6.setValue(dateListedType6);
+
+        hearingWithInvalidDate.getValue().getHearingDateCollection().add(dateListedTypeItem6);
+
+        List<Integer> validHearingsCountList = new ArrayList<>();
+        submitEvents.stream().forEach(caseData ->
+            validHearingsCountList.add(caseData.getCaseData().getHearingCollection().stream()
+                .filter(h -> FULL_PANEL.equals(h.getValue().getHearingSitAlone()))
+                .collect(Collectors.toList()).size()));
+
+        List<DateListedTypeItem> dateListedTypeItems = new ArrayList<>();
+        //filter listed hearings with full panel
+        for(var submitEvent :submitEvents) {
+            for(var hearing : submitEvent.getCaseData().getHearingCollection()) {
+                var validDates = hearing.getValue().getHearingDateCollection()
+                    .stream().filter(h -> isValidDate(h.getValue().getListedDate(),
+                        listingDetails.getCaseData().getListingDateFrom(),
+                        listingDetails.getCaseData().getListingDateTo()))
+                    .collect(Collectors.toList());
+                validDates.forEach(vd -> dateListedTypeItems.add(vd));
+            }
+        }
+
+        var expectedValidHearingDatesCount = dateListedTypeItems.stream().distinct().count();
+        var expectedReportDateType = "Range";
+        var resultListingData = memberDaysReport.runReport(listingDetails, submitEvents);
+
+        var actualValidHearingDatesCount  = resultListingData.getReportDetails().size();
+        var actualReportDateType = resultListingData.getHearingDateType();
+
+        assertEquals(expectedValidHearingDatesCount, actualValidHearingDatesCount);
+        assertEquals(expectedReportDateType, actualReportDateType);
+    }
+
+    @Test
     public void shouldReturnZeroHearingDurationForNullHearingTimingStart() {
         var memberDaysReport = new MemberDaysReport();
         submitEvents.remove(2);


### PR DESCRIPTION
Millisecond check added while hearing break and resume times date parsing. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
