### PR TITLE
ECM-580/604

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ ext {
 }
 
 dependencies {
-    implementation group: 'com.github.hmcts', name: 'ecm-common', version: '0.1.166'
+    implementation group: 'com.github.hmcts', name: 'ecm-common', version: '0.1.168'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '6.0.0'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion

--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ ext {
 }
 
 dependencies {
-    implementation group: 'com.github.hmcts', name: 'ecm-common', version: '0.1.168'
+    implementation group: 'com.github.hmcts', name: 'ecm-common', version: '0.1.167'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '6.0.0'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.ethos.replacement.docmosis.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ecm.common.client.CcdClient;
 import uk.gov.hmcts.ecm.common.exceptions.CaseCreationException;
@@ -34,6 +35,7 @@ import uk.gov.hmcts.ethos.replacement.docmosis.reports.nochangeincurrentposition
 import uk.gov.hmcts.ethos.replacement.docmosis.reports.nochangeincurrentposition.NoPositionChangeReportData;
 import uk.gov.hmcts.ethos.replacement.docmosis.reports.servingclaims.ServingClaimsReport;
 import uk.gov.hmcts.ethos.replacement.docmosis.reports.timetofirsthearing.TimeToFirstHearingReport;
+
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -285,6 +287,7 @@ public class ListingService {
     }
 
     private ListingData getDateRangeReport(ListingDetails listingDetails, String authToken) throws IOException {
+        checkForExistingData(listingDetails.getCaseData());
         List<SubmitEvent> submitEvents = getDateRangeReportSearch(listingDetails, authToken);
 
         switch (listingDetails.getCaseData().getReportType()) {
@@ -309,6 +312,19 @@ public class ListingService {
                 return new MemberDaysReport().runReport(listingDetails, submitEvents);
             default:
                 return listingDetails.getCaseData();
+        }
+    }
+
+    private void checkForExistingData(ListingData listingData) {
+        if (CollectionUtils.isNotEmpty(listingData.getLocalReportsDetail())
+                || listingData.getLocalReportsDetailHdr() != null
+                || CollectionUtils.isNotEmpty(listingData.getLocalReportsSummary())) {
+            listingData.setLocalReportsDetail(null);
+            listingData.setLocalReportsDetailHdr(null);
+            listingData.setLocalReportsSummary(null);
+            listingData.setLocalReportsSummary2(null);
+            listingData.setLocalReportsSummaryHdr(null);
+            listingData.setLocalReportsSummaryHdr2(null);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.ethos.replacement.docmosis.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ecm.common.client.CcdClient;
 import uk.gov.hmcts.ecm.common.exceptions.CaseCreationException;

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
@@ -329,7 +329,7 @@ public class ListingService {
         listingData.setLocalReportsSummaryHdr2(null);
         listingData.setLocalReportsSummary2(null);
         listingData.setLocalReportsDetailHdr(null);
-        listingData.setLocalReportsDetail(null;)
+        listingData.setLocalReportsDetail(null);
     }
 
     private void setListingDateRangeForSearch(ListingDetails listingDetails) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
@@ -317,14 +317,9 @@ public class ListingService {
 
     private void checkForExistingData(ListingData listingData) {
         if (CollectionUtils.isNotEmpty(listingData.getLocalReportsDetail())
-                || listingData.getLocalReportsDetailHdr() != null
-                || CollectionUtils.isNotEmpty(listingData.getLocalReportsSummary())) {
-            listingData.setLocalReportsDetail(null);
-            listingData.setLocalReportsDetailHdr(null);
-            listingData.setLocalReportsSummary(null);
-            listingData.setLocalReportsSummary2(null);
-            listingData.setLocalReportsSummaryHdr(null);
-            listingData.setLocalReportsSummaryHdr2(null);
+                || CollectionUtils.isNotEmpty(listingData.getLocalReportsSummary())
+                || listingData.getLocalReportsDetailHdr() != null) {
+            listingData.clearLocalReportFields();
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
@@ -319,8 +319,17 @@ public class ListingService {
         if (CollectionUtils.isNotEmpty(listingData.getLocalReportsDetail())
                 || CollectionUtils.isNotEmpty(listingData.getLocalReportsSummary())
                 || listingData.getLocalReportsDetailHdr() != null) {
-            listingData.clearLocalReportFields();
+            clearListingFields(listingData);
         }
+    }
+
+    private void clearListingFields(ListingData listingData) {
+        listingData.setLocalReportsSummary(null);
+        listingData.setLocalReportsSummaryHdr(null);
+        listingData.setLocalReportsSummaryHdr2(null);
+        listingData.setLocalReportsSummary2(null);
+        listingData.setLocalReportsDetailHdr(null);
+        listingData.setLocalReportsDetail(null;)
     }
 
     private void setListingDateRangeForSearch(ListingDetails listingDetails) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingService.java
@@ -287,7 +287,7 @@ public class ListingService {
     }
 
     private ListingData getDateRangeReport(ListingDetails listingDetails, String authToken) throws IOException {
-        checkForExistingData(listingDetails.getCaseData());
+        clearListingFields(listingDetails.getCaseData());
         List<SubmitEvent> submitEvents = getDateRangeReportSearch(listingDetails, authToken);
 
         switch (listingDetails.getCaseData().getReportType()) {
@@ -312,14 +312,6 @@ public class ListingService {
                 return new MemberDaysReport().runReport(listingDetails, submitEvents);
             default:
                 return listingDetails.getCaseData();
-        }
-    }
-
-    private void checkForExistingData(ListingData listingData) {
-        if (CollectionUtils.isNotEmpty(listingData.getLocalReportsDetail())
-                || CollectionUtils.isNotEmpty(listingData.getLocalReportsSummary())
-                || listingData.getLocalReportsDetailHdr() != null) {
-            clearListingFields(listingData);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingServiceTest.java
@@ -972,12 +972,11 @@ public class ListingServiceTest {
         listingDetails.getCaseData().setLocalReportsSummary(localReportsSummary);
         listingDetails.setCaseTypeId(MANCHESTER_LISTING_CASE_TYPE_ID);
         listingDetails.getCaseData().setReportType(CLAIMS_ACCEPTED_REPORT);
-
         submitEvents.remove(0);
-        System.out.println(submitEvents);
+        
         when(ccdClient.retrieveCasesGenericReportElasticSearch(anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(submitEvents);
         ListingData listingDataResult = listingService.generateReportData(listingDetails, "authToken");
-        System.out.println(listingDataResult.getLocalReportsSummary());
+
         assertTrue(CollectionUtils.isEmpty(listingDataResult.getLocalReportsDetail()));
         assertTrue(CollectionUtils.isEmpty(listingDataResult.getLocalReportsSummary2()));
         assertTrue(CollectionUtils.isEmpty(listingDataResult.getLocalReportsSummary()));

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/ListingServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.service;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,8 @@ import uk.gov.hmcts.ecm.common.model.ccd.types.RepresentedTypeR;
 import uk.gov.hmcts.ecm.common.model.ccd.types.RespondentSumType;
 import uk.gov.hmcts.ecm.common.model.listing.ListingData;
 import uk.gov.hmcts.ecm.common.model.listing.ListingDetails;
+import uk.gov.hmcts.ecm.common.model.listing.items.AdhocReportTypeItem;
+import uk.gov.hmcts.ecm.common.model.listing.types.AdhocReportType;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleData;
 import uk.gov.hmcts.ecm.common.model.multiples.SubmitMultipleEvent;
 import uk.gov.hmcts.ecm.common.model.reports.hearingstojudgments.HearingsToJudgmentsSubmitEvent;
@@ -55,6 +58,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -950,6 +955,36 @@ public class ListingServiceTest {
         submitEvents.get(0).getCaseData().setManagingOffice("Glasgow");
         ListingData listingDataResult = listingService.generateReportData(listingDetails, "authToken");
         assertEquals(result, listingDataResult.toString());
+    }
+
+    @Test
+    public void checkExistingDataInReport() throws IOException {
+        var adhocReportType = new AdhocReportType();
+        adhocReportType.setSinglesTotal("6");
+        adhocReportType.setMultiplesTotal("10");
+        listingDetails.getCaseData().setLocalReportsSummaryHdr(adhocReportType);
+        var adhocReportType2 = new AdhocReportType();
+        adhocReportType2.setCaseReference("1800001/2021");
+        adhocReportType2.setDateOfAcceptance("2021-01-01");
+        var adhocReportTypeItem = new AdhocReportTypeItem();
+        adhocReportTypeItem.setValue(adhocReportType2);
+        List<AdhocReportTypeItem> localReportsSummary = List.of(adhocReportTypeItem);
+        listingDetails.getCaseData().setLocalReportsSummary(localReportsSummary);
+        listingDetails.setCaseTypeId(MANCHESTER_LISTING_CASE_TYPE_ID);
+        listingDetails.getCaseData().setReportType(CLAIMS_ACCEPTED_REPORT);
+
+        submitEvents.remove(0);
+        System.out.println(submitEvents);
+        when(ccdClient.retrieveCasesGenericReportElasticSearch(anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(submitEvents);
+        ListingData listingDataResult = listingService.generateReportData(listingDetails, "authToken");
+        System.out.println(listingDataResult.getLocalReportsSummary());
+        assertTrue(CollectionUtils.isEmpty(listingDataResult.getLocalReportsDetail()));
+        assertTrue(CollectionUtils.isEmpty(listingDataResult.getLocalReportsSummary2()));
+        assertTrue(CollectionUtils.isEmpty(listingDataResult.getLocalReportsSummary()));
+        assertNull(listingDataResult.getLocalReportsDetailHdr());
+        assertNull(listingDataResult.getLocalReportsSummaryHdr());
+        assertNull(listingDataResult.getLocalReportsSummaryHdr2());
+
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ECM-580
https://tools.hmcts.net/jira/browse/ECM-604

### Change description ###

Set LocalReports details to null if data exists as if ElasticSearch found 0 cases, it would retain the previous data and show it despite not meeting the query

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
