### PR TITLE
DocStore and Base Helm Chart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,7 +209,8 @@ def versions = [
         springfoxSwagger: '2.9.2',
         serenity        : '2.3.31',
         pact_version    : '4.1.7',
-        tomcat_embed    : '9.0.58'
+        tomcat_embed    : '9.0.58',
+        netty           : '4.1.74.Final'
 ]
 
 ext {
@@ -248,7 +249,7 @@ dependencies {
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.24'
     implementation('org.elasticsearch:elasticsearch') {
         version {
-            strictly '7.13.4'
+            strictly '7.17.0'
         }
     }
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.5.RELEASE'
@@ -266,12 +267,50 @@ dependencies {
     //To Remove vulnerability CVE-2020-11988
     implementation group: 'org.apache.xmlgraphics', name: 'xmlgraphics-commons', version: '2.6'
 
-    //CVE-2021-43206
-    implementation group: 'com.microsoft.azure', name: 'adal4j', version: '1.6.7'
+    //CVE-2021-42550
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
 
     //CVE-2021-22060
     implementation group: 'org.springframework', name: 'spring-core', version: '5.3.15'
 
+    // CVE-2021-37136, CVE-2021-37137, CVE-2021-43797
+    implementation group: 'io.netty', name: 'netty-all', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-buffer', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-http', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-http2', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-socks', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-common', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-handler', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-handler-proxy', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-resolver', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-transport', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-resolver-dns-native-macos', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-dns', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-haproxy', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-memcache', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-mqtt', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-redis', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-smtp', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-stomp', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-codec-xml', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-resolver-dns', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-transport-rxtx', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-transport-sctp', version: versions.netty
+    implementation group: 'io.netty', name: 'netty-transport-udt', version: versions.netty
+
+    // CVE-2021-40690
+    implementation group: 'org.apache.santuario', name: 'xmlsec', version: '2.3.0'
+
+    // CVE-2021-28170
+    testImplementation group: 'org.glassfish', name: 'jakarta.el', version: '3.0.4'
+
+    // CVE-202-23171
+    implementation group: 'com.nimbusds', name: 'lang-tag', version: '1.5'
 
     implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: '11.6'
     implementation group: 'io.github.openfeign', name: 'feign-core', version: '11.6'

--- a/build.gradle
+++ b/build.gradle
@@ -208,12 +208,13 @@ repositories {
 def versions = [
         springfoxSwagger: '2.9.2',
         serenity        : '2.3.31',
-        pact_version    : '4.1.7'
+        pact_version    : '4.1.7',
+        tomcat_embed    : '9.0.58'
 ]
 
 ext {
     reformLoggingVersion = '5.1.9'
-    log4JVersion = '2.17.0'
+    log4JVersion = '2.17.1'
 }
 
 dependencies {
@@ -240,8 +241,8 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.21'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
     implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.48'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.48'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcat_embed
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: versions.tomcat_embed
 
 // For pdfbox and elasticsearch CVEs
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.24'
@@ -264,6 +265,13 @@ dependencies {
 
     //To Remove vulnerability CVE-2020-11988
     implementation group: 'org.apache.xmlgraphics', name: 'xmlgraphics-commons', version: '2.6'
+
+    //CVE-2021-43206
+    implementation group: 'com.microsoft.azure', name: 'adal4j', version: '1.6.7'
+
+    //CVE-2021-22060
+    implementation group: 'org.springframework', name: 'spring-core', version: '5.3.15'
+
 
     implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: '11.6'
     implementation group: 'io.github.openfeign', name: 'feign-core', version: '11.6'

--- a/charts/ethos-repl-docmosis-backend/Chart.yaml
+++ b/charts/ethos-repl-docmosis-backend/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: ethos-repl-docmosis-backend
 home: https://github.com/hmcts/ethos-repl-docmosis-service
-version: 0.3.2
+version: 0.3.3
 description: HMCTS Ethos Replacement Docmosis Service
 maintainers:
   - name: HMCTS ETHOS Team
     email: james.turnbull@justice.gov.uk
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/

--- a/charts/ethos-repl-docmosis-backend/values.yaml
+++ b/charts/ethos-repl-docmosis-backend/values.yaml
@@ -38,4 +38,4 @@ java:
     ETHOS_REPL_DB_PORT: '5432'
     ETHOS_REPL_DB_USER_NAME: ethos@ethos-postgres-db-{{ .Values.global.environment }}
     CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    SECURE_DOC_STORE_FEATURE: false
+    SECURE_DOC_STORE_FEATURE: true

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,28 +15,13 @@
         <vulnerabilityName>CVE-2020-23171</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes>
-            <![CDATA[file name: elasticsearch-7.13.4.jar]]>
-        </notes>
-        <packageUrl regex="true">^pkg:maven/org.elasticsearch/elasticsearch@.*$</packageUrl>
-        <vulnerabilityName>CVE-2021-22147</vulnerabilityName>
+        <notes><![CDATA[
+   file name: netty-tcnative-classes-2.0.48.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
     </suppress>
     <suppress>
-        <vulnerabilityName>CVE-2021-40690</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <vulnerabilityName>CVE-2021-42340</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <vulnerabilityName>CVE-2021-37136</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <vulnerabilityName>CVE-2021-37137</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <vulnerabilityName>CVE-2021-22096</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <vulnerabilityName>CVE-2021-43797</vulnerabilityName>
+        <vulnerabilityName>CVE-2021-42306</vulnerabilityName>
     </suppress>
 </suppressions>


### PR DESCRIPTION
Base Helm Chart update as 3.6.0 will be outdated

Turning SecureDocStore on in Production