### PR TITLE
BF comment bug fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/bfaction/BfActionReport.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/bfaction/BfActionReport.java
@@ -85,7 +85,12 @@ public class BfActionReport {
 
         bfDateType.setBroughtForwardEnteredDate(bfActionType.getDateEntered());
         bfDateType.setBroughtForwardDate(bfDate);
-        bfDateType.setBroughtForwardDateReason(bfActionType.getNotes());
+
+        if (!isNullOrEmpty(bfActionType.getNotes())) {
+            var bfReason = bfActionType.getNotes().replace("\n", ". ");
+            bfDateType.setBroughtForwardDateReason(bfReason);
+        }
+
         var bfDateTypeItem = new BFDateTypeItem();
         bfDateTypeItem.setId(String.valueOf(bfActionTypeItem.getId()));
         bfDateTypeItem.setValue(bfDateType);

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/bfaction/BfActionReportTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/reports/bfaction/BfActionReportTest.java
@@ -45,7 +45,8 @@ public class BfActionReportTest {
         listingDetails.setCaseData(listingData);
         bfActionReport = new BfActionReport();
         submitEvent = new SubmitEvent();
-
+        submitEvent.setCaseId(2);
+        submitEvent.setState(ACCEPTED_STATE);
         caseData = new CaseData();
         caseData.setEthosCaseReference("1800522/2020");
         caseData.setReceiptDate("2018-08-10");
@@ -101,9 +102,6 @@ public class BfActionReportTest {
         items.add(bfActionTypeItem4);
 
         caseData.setBfActions(items);
-
-        submitEvent.setCaseId(2);
-        submitEvent.setState(ACCEPTED_STATE);
         submitEvent.setCaseData(caseData);
         submitEvents.add(submitEvent);
 
@@ -140,10 +138,7 @@ public class BfActionReportTest {
         bFActionType.setNotes("test comment one");
         bfActionTypeItem.setValue(bFActionType);
         items.add(bfActionTypeItem);
-
         caseData.setBfActions(items);
-        submitEvent.setCaseId(2);
-        submitEvent.setState(ACCEPTED_STATE);
         submitEvent.setCaseData(caseData);
         submitEvents.add(submitEvent);
 
@@ -166,10 +161,7 @@ public class BfActionReportTest {
         // Two bf action entries added and the second BFActionTypeItem has
         // the "YYYY-MM-DD HH:MM:SS" date and time pattern without milliseconds for the BfDate
         List<BFActionTypeItem> items = getBFActionTypeItems();
-
         caseData.setBfActions(items);
-        submitEvent.setCaseId(2);
-        submitEvent.setState(ACCEPTED_STATE);
         submitEvent.setCaseData(caseData);
         submitEvents.add(submitEvent);
 
@@ -194,10 +186,7 @@ public class BfActionReportTest {
         bFActionType4.setNotes("test case with cleared bfs");
         bfActionTypeItem4.setValue(bFActionType4);
         items.add(bfActionTypeItem4);
-
         caseData.setBfActions(items);
-        submitEvent.setCaseId(2);
-        submitEvent.setState(ACCEPTED_STATE);
         submitEvent.setCaseData(caseData);
         submitEvents.add(submitEvent);
 
@@ -224,13 +213,9 @@ public class BfActionReportTest {
         bfActionTypeItem6.setValue(bFActionType6);
         items.add(bfActionTypeItem6);
         caseData.setBfActions(items);
-        var bfActionReport = new BfActionReport();
-
-        submitEvent.setCaseId(2);
-        submitEvent.setState(ACCEPTED_STATE);
         submitEvent.setCaseData(caseData);
         submitEvents.add(submitEvent);
-
+        var bfActionReport = new BfActionReport();
         var resultListingData = bfActionReport.runReport(listingDetails, submitEvents);
         // bFActionType3 is added last. But it has the earliest bfDate. As the returned listingData from
         // bfActionReport.runReport method call should be ordered by bfDate, bFActionType3
@@ -242,6 +227,39 @@ public class BfActionReportTest {
         assertEquals(bFActionType3.getNotes(), firstBFDateTypeItem.getBroughtForwardDateReason());
         assertEquals(bFActionType3.getDateEntered(), firstBFDateTypeItem.getBroughtForwardEnteredDate());
         assertEquals(bFActionType3.getCleared(), firstBFDateTypeItem.getBroughtForwardDateCleared());
+    }
+
+    @Test
+    public void shouldReturnBfActionsWithFormattedComment() {
+        listingData.setListingDateFrom("2019-12-03");
+        listingData.setListingDateTo("2019-12-28");
+        listingData.setHearingDateType(RANGE_HEARING_DATE_TYPE);
+        listingDetails.setCaseData(listingData);
+
+        List<BFActionTypeItem> items = getBFActionTypeItems();
+
+        var bfActionTypeItemFour = new BFActionTypeItem();
+        bfActionTypeItemFour.setId("1488");
+        var bFActionTypeFour = new BFActionType();
+        bFActionTypeFour.setCwActions("Another order requested");
+        bFActionTypeFour.setBfDate("2019-12-07");
+        bFActionTypeFour.setDateEntered("2019-11-25");
+        bFActionTypeFour.setNotes("test non-cleared bf two\n Second line comment");
+        bfActionTypeItemFour.setValue(bFActionTypeFour);
+
+        items.add(bfActionTypeItemFour);
+        caseData.setBfActions(items);
+        submitEvent.setCaseData(caseData);
+        submitEvents.add(submitEvent);
+
+        var bfActionReport = new BfActionReport();
+        var resultListingData = bfActionReport.runReport(listingDetails, submitEvents);
+        //Because the Bf entries are sorted by bf date, bfActionTypeItemFour is the first entry in the
+        //result listing data
+        var firstBFDateTypeItem = resultListingData.getBfDateCollection().get(0).getValue();
+        var correctedComment = bfActionTypeItemFour.getValue().getNotes()
+            .replace("\n", ". ");
+        assertEquals(correctedComment, firstBFDateTypeItem.getBroughtForwardDateReason());
     }
 
     private List<BFActionTypeItem> getBFActionTypeItems() {


### PR DESCRIPTION
A multiline comment support is added in BF report so that the prod error is resolved.

https://tools.hmcts.net/jira/browse/ECM-654

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
