### PR TITLE
ECM-660 Stop Closing case with Outstanding BFs

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,4 +14,32 @@
         <packageUrl regex="true">^pkg:npm/randomstring@.*$</packageUrl>
         <vulnerabilityName>Possible SQL injection in mysql.escape function</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: poi-5.0.0.jar
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org.apache.poi/poi@5.0.0</packageUrl>
+        <cve>CVE-2022-26336</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: poi-ooxml-lite-5.0.0.jar
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org.apache.poi/poi-ooxml-lite@5.0.0</packageUrl>
+        <cve>CVE-2022-26336</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: poi-ooxml-5.0.0.jar
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org.apache.poi/poi-ooxml@5.0.0</packageUrl>
+        <cve>CVE-2022-26336</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: minimist:1.2.5
+    ]]></notes>
+        <packageUrl regex="true">^pkg:npm/minimist@.*$</packageUrl>
+        <vulnerabilityName>1067285</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -35,11 +35,4 @@
         <packageUrl regex="true">^pkg:maven/org.apache.poi/poi-ooxml@5.0.0</packageUrl>
         <cve>CVE-2022-26336</cve>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-    file name: minimist:1.2.5
-    ]]></notes>
-        <packageUrl regex="true">^pkg:npm/minimist@.*$</packageUrl>
-        <vulnerabilityName>1067285</vulnerabilityName>
-    </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
@@ -27,7 +27,7 @@ import uk.gov.hmcts.ethos.replacement.docmosis.helpers.dynamiclists.DynamicJudge
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.dynamiclists.DynamicRespondentRepresentative;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.dynamiclists.DynamicRestrictedReporting;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.AddSingleCaseToMultipleService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseService;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCreationForCaseWorkerService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseManagementForCaseWorkerService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseRetrievalForCaseWorkerService;
@@ -70,7 +70,6 @@ public class CaseActionsForCaseWorkerController {
     private static final String INVALID_TOKEN = "Invalid Token {}";
     private static final String EVENT_FIELDS_VALIDATION = "Event fields validation: ";
     private final CaseTransferService caseTransferService;
-    private final CaseCloseService caseCloseService;
     private final CaseCreationForCaseWorkerService caseCreationForCaseWorkerService;
     private final CaseRetrievalForCaseWorkerService caseRetrievalForCaseWorkerService;
     private final CaseUpdateForCaseWorkerService caseUpdateForCaseWorkerService;
@@ -1166,7 +1165,7 @@ public class CaseActionsForCaseWorkerController {
         }
 
         var caseData =  ccdRequest.getCaseDetails().getCaseData();
-        List<String> errors = caseCloseService.validateReinstateClosedCaseMidEvent(caseData);
+        List<String> errors = CaseCloseValidator.validateReinstateClosedCaseMidEvent(caseData);
 
         return getCallbackRespEntityErrors(errors, caseData);
     }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
 
@@ -15,6 +16,8 @@ public class CaseCloseService {
 
     static final String REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE = "This case cannot be reinstated with a "
             + "current position of Case closed. Please select a different current position.";
+    static final String CLOSING_CASE_WITH_BF_OPEN_ERROR = "This case contains one or more outstanding BFs. "
+            + "To enable this case to be closed, please clear the outstanding BFs.";
 
     public List<String> validateReinstateClosedCaseMidEvent(CaseData caseData) {
         List<String> errors = new ArrayList<>();
@@ -22,6 +25,21 @@ public class CaseCloseService {
             errors.add(REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE);
         }
         return errors;
+    }
+
+    public void validateBfActionsForCaseCloseEvent(CaseData caseData, List<String> errors) {
+
+        if (CollectionUtils.isEmpty(caseData.getBfActions())) {
+            return;
+        }
+
+        for (var currentBFActionTypeItem : caseData.getBfActions()) {
+            if (currentBFActionTypeItem.getValue().getCleared() == null) {
+                errors.add(CLOSING_CASE_WITH_BF_OPEN_ERROR);
+                return;
+            }
+        }
+
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseService.java
@@ -27,19 +27,17 @@ public class CaseCloseService {
         return errors;
     }
 
-    public void validateBfActionsForCaseCloseEvent(CaseData caseData, List<String> errors) {
-
+    public List<String> validateBfActionsForCaseCloseEvent(CaseData caseData) {
+        List<String> errors = new ArrayList<>();
         if (CollectionUtils.isEmpty(caseData.getBfActions())) {
-            return;
+            return errors;
         }
-
         for (var currentBFActionTypeItem : caseData.getBfActions()) {
             if (currentBFActionTypeItem.getValue().getCleared() == null) {
                 errors.add(CLOSING_CASE_WITH_BF_OPEN_ERROR);
-                return;
+                return errors;
             }
         }
-
+        return errors;
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseValidator.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseValidator.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.ethos.replacement.docmosis.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
 
 import java.util.ArrayList;
@@ -11,15 +10,17 @@ import java.util.List;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CASE_CLOSED_POSITION;
 
 @Slf4j
-@Service("caseCloseService")
-public class CaseCloseService {
+public class CaseCloseValidator {
+
+    private CaseCloseValidator() {
+    }
 
     static final String REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE = "This case cannot be reinstated with a "
             + "current position of Case closed. Please select a different current position.";
     static final String CLOSING_CASE_WITH_BF_OPEN_ERROR = "This case contains one or more outstanding BFs. "
             + "To enable this case to be closed, please clear the outstanding BFs.";
 
-    public List<String> validateReinstateClosedCaseMidEvent(CaseData caseData) {
+    public static List<String> validateReinstateClosedCaseMidEvent(CaseData caseData) {
         List<String> errors = new ArrayList<>();
         if (CASE_CLOSED_POSITION.equals(caseData.getPositionType())) {
             errors.add(REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE);
@@ -27,7 +28,7 @@ public class CaseCloseService {
         return errors;
     }
 
-    public List<String> validateBfActionsForCaseCloseEvent(CaseData caseData) {
+    public static List<String> validateBfActionsForCaseCloseEvent(CaseData caseData) {
         List<String> errors = new ArrayList<>();
         if (CollectionUtils.isEmpty(caseData.getBfActions())) {
             return errors;

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.service;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -64,8 +65,11 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.TARGET_HEARING_DATE
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.Helper.getActiveRespondents;
 
 @Slf4j
+@RequiredArgsConstructor
 @Service("eventValidationService")
 public class EventValidationService {
+
+    private final CaseCloseService caseCloseService;
 
     private static final List<String> INVALID_STATES_FOR_CLOSED_CURRENT_POSITION = List.of(
             SUBMITTED_STATE, ACCEPTED_STATE, REJECTED_STATE);
@@ -432,6 +436,7 @@ public class EventValidationService {
         validateJudgementsHasJurisdiction(caseData, partOfMultiple, errors);
         validateHearingStatusForCaseCloseEvent(caseData, errors);
         validateHearingJudgeAllocationForCaseCloseEvent(caseData, errors);
+        caseCloseService.validateBfActionsForCaseCloseEvent(caseData, errors);
         return errors;
     }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
@@ -69,8 +69,6 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.Helper.getActiveRe
 @Service("eventValidationService")
 public class EventValidationService {
 
-    private final CaseCloseService caseCloseService;
-
     private static final List<String> INVALID_STATES_FOR_CLOSED_CURRENT_POSITION = List.of(
             SUBMITTED_STATE, ACCEPTED_STATE, REJECTED_STATE);
 
@@ -436,7 +434,7 @@ public class EventValidationService {
         validateJudgementsHasJurisdiction(caseData, partOfMultiple, errors);
         validateHearingStatusForCaseCloseEvent(caseData, errors);
         validateHearingJudgeAllocationForCaseCloseEvent(caseData, errors);
-        errors.addAll(caseCloseService.validateBfActionsForCaseCloseEvent(caseData));
+        errors.addAll(CaseCloseValidator.validateBfActionsForCaseCloseEvent(caseData));
         return errors;
     }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
@@ -436,7 +436,7 @@ public class EventValidationService {
         validateJudgementsHasJurisdiction(caseData, partOfMultiple, errors);
         validateHearingStatusForCaseCloseEvent(caseData, errors);
         validateHearingJudgeAllocationForCaseCloseEvent(caseData, errors);
-        caseCloseService.validateBfActionsForCaseCloseEvent(caseData, errors);
+        errors.addAll(caseCloseService.validateBfActionsForCaseCloseEvent(caseData));
         return errors;
     }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleCloseEventValidationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleCloseEventValidationService.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.service.excel;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.EventValidationService;
@@ -12,21 +12,13 @@ import java.util.List;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.REJECTED_STATE;
 
 @Slf4j
+@RequiredArgsConstructor
 @Service("multipleCloseEventValidationService")
 public class MultipleCloseEventValidationService {
 
     private final SingleCasesReadingService singleCasesReadingService;
     private final MultipleHelperService multipleHelperService;
     private final EventValidationService eventValidationService;
-
-    @Autowired
-    public MultipleCloseEventValidationService(SingleCasesReadingService singleCasesReadingService,
-                                               MultipleHelperService multipleHelperService,
-                                               EventValidationService eventValidationService) {
-        this.singleCasesReadingService = singleCasesReadingService;
-        this.multipleHelperService = multipleHelperService;
-        this.eventValidationService = eventValidationService;
-    }
 
     public List<String> validateCasesBeforeCloseEvent(String userToken, MultipleDetails multipleDetails) {
         List<String> errors = new ArrayList<>();

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerControllerTest.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.ecm.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.ecm.common.model.helper.DefaultValues;
 import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.AddSingleCaseToMultipleService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseService;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCreationForCaseWorkerService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseManagementForCaseWorkerService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseRetrievalForCaseWorkerService;
@@ -115,9 +115,6 @@ public class CaseActionsForCaseWorkerControllerTest {
 
     @Autowired
     private WebApplicationContext applicationContext;
-
-    @MockBean
-    private CaseCloseService caseCloseService;
 
     @MockBean
     private CaseCreationForCaseWorkerService caseCreationForCaseWorkerService;
@@ -793,7 +790,6 @@ public class CaseActionsForCaseWorkerControllerTest {
     @Test
     public void reinstateClosedCaseMidEventValidation() throws Exception {
         when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
-        when(caseCloseService.validateReinstateClosedCaseMidEvent(isA(CaseData.class))).thenReturn(anyList());
         mvc.perform(post(REINSTATE_CLOSED_CASE_MID_EVENT_VALIDATION_URL)
                 .content(requestContent.toString())
                 .header("Authorization", AUTH_TOKEN)
@@ -807,15 +803,13 @@ public class CaseActionsForCaseWorkerControllerTest {
     @Test
     public void reinstateClosedCaseMidEventValidationErrors() throws Exception {
         when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
-        when(caseCloseService.validateReinstateClosedCaseMidEvent(isA(CaseData.class)))
-                .thenReturn(List.of("test error"));
         mvc.perform(post(REINSTATE_CLOSED_CASE_MID_EVENT_VALIDATION_URL)
                 .content(requestContent.toString())
                 .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data", notNullValue()))
-                .andExpect(jsonPath("$.errors", hasSize(1)))
+                .andExpect(jsonPath("$.errors", notNullValue()))
                 .andExpect(jsonPath("$.warnings", nullValue()));
     }
 
@@ -1151,7 +1145,6 @@ public class CaseActionsForCaseWorkerControllerTest {
                         .header("Authorization", AUTH_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
-        verify(caseCloseService, never()).validateReinstateClosedCaseMidEvent(any(CaseData.class));
     }
 
     @Test
@@ -1680,7 +1673,6 @@ public class CaseActionsForCaseWorkerControllerTest {
                         .header("Authorization", AUTH_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isForbidden());
-        verify(caseCloseService, never()).validateReinstateClosedCaseMidEvent(caseData);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseServiceTest.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.helpers.BFHelperTest;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -47,28 +46,25 @@ class CaseCloseServiceTest {
 
     @Test
     void shouldValidateBfActionsForCaseCloseEvent_AllCleared_Pass() {
-        List<String> errors = new ArrayList<>();
         caseData.setBfActions(BFHelperTest.generateBFActionTypeItems());
         caseData.getBfActions().get(0).getValue().setCleared("2022-02-22");
-        caseCloseService.validateBfActionsForCaseCloseEvent(caseData, errors);
+        List<String> errors = caseCloseService.validateBfActionsForCaseCloseEvent(caseData);
         assertEquals(0, errors.size());
     }
 
     @Test
     void shouldValidateBfActionsForCaseCloseEvent_NotCleared_Error() {
-        List<String> errors = new ArrayList<>();
         caseData.setBfActions(BFHelperTest.generateBFActionTypeItems());
         caseData.getBfActions().get(0).getValue().setCleared(null);
-        caseCloseService.validateBfActionsForCaseCloseEvent(caseData, errors);
+        List<String> errors = caseCloseService.validateBfActionsForCaseCloseEvent(caseData);
         assertEquals(1, errors.size());
         assertEquals(CLOSING_CASE_WITH_BF_OPEN_ERROR, errors.get(0));
     }
 
     @Test
     void shouldValidateBfActionsForCaseCloseEvent_NoBF_Pass() {
-        List<String> errors = new ArrayList<>();
         caseData.setBfActions(null);
-        caseCloseService.validateBfActionsForCaseCloseEvent(caseData, errors);
+        List<String> errors = caseCloseService.validateBfActionsForCaseCloseEvent(caseData);
         assertEquals(0, errors.size());
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseServiceTest.java
@@ -1,13 +1,21 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
+import uk.gov.hmcts.ecm.common.model.ccd.CaseDetails;
+import uk.gov.hmcts.ethos.replacement.docmosis.helpers.BFHelperTest;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CASE_CLOSED_POSITION;
+import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseService.CLOSING_CASE_WITH_BF_OPEN_ERROR;
 import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseService.REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE;
 
 class CaseCloseServiceTest {
@@ -18,7 +26,8 @@ class CaseCloseServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         caseCloseService = new CaseCloseService();
-        caseData = new CaseData();
+        CaseDetails caseDetails = generateCaseDetails("caseDetailsTest1.json");
+        caseData = caseDetails.getCaseData();
     }
 
     @Test
@@ -35,4 +44,39 @@ class CaseCloseServiceTest {
         List<String> errors = caseCloseService.validateReinstateClosedCaseMidEvent(caseData);
         assertEquals(0, errors.size());
     }
+
+    @Test
+    void shouldValidateBfActionsForCaseCloseEvent_AllCleared_Pass() {
+        List<String> errors = new ArrayList<>();
+        caseData.setBfActions(BFHelperTest.generateBFActionTypeItems());
+        caseData.getBfActions().get(0).getValue().setCleared("2022-02-22");
+        caseCloseService.validateBfActionsForCaseCloseEvent(caseData, errors);
+        assertEquals(0, errors.size());
+    }
+
+    @Test
+    void shouldValidateBfActionsForCaseCloseEvent_NotCleared_Error() {
+        List<String> errors = new ArrayList<>();
+        caseData.setBfActions(BFHelperTest.generateBFActionTypeItems());
+        caseData.getBfActions().get(0).getValue().setCleared(null);
+        caseCloseService.validateBfActionsForCaseCloseEvent(caseData, errors);
+        assertEquals(1, errors.size());
+        assertEquals(CLOSING_CASE_WITH_BF_OPEN_ERROR, errors.get(0));
+    }
+
+    @Test
+    void shouldValidateBfActionsForCaseCloseEvent_NoBF_Pass() {
+        List<String> errors = new ArrayList<>();
+        caseData.setBfActions(null);
+        caseCloseService.validateBfActionsForCaseCloseEvent(caseData, errors);
+        assertEquals(0, errors.size());
+    }
+
+    private CaseDetails generateCaseDetails(String jsonFileName) throws Exception {
+        String json = new String(Files.readAllBytes(Paths.get(Objects.requireNonNull(getClass().getClassLoader()
+                .getResource(jsonFileName)).toURI())));
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CaseDetails.class);
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseServiceTest.java
@@ -14,17 +14,15 @@ import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CASE_CLOSED_POSITION;
-import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseService.CLOSING_CASE_WITH_BF_OPEN_ERROR;
-import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseService.REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE;
+import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator.CLOSING_CASE_WITH_BF_OPEN_ERROR;
+import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator.REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE;
 
 class CaseCloseServiceTest {
 
-    private CaseCloseService caseCloseService;
     private CaseData caseData;
 
     @BeforeEach
     public void setup() throws Exception {
-        caseCloseService = new CaseCloseService();
         CaseDetails caseDetails = generateCaseDetails("caseDetailsTest1.json");
         caseData = caseDetails.getCaseData();
     }
@@ -32,7 +30,7 @@ class CaseCloseServiceTest {
     @Test
     void shouldValidateReinstateClosedCase_IsCaseClose_ReturnOne() {
         caseData.setPositionType(CASE_CLOSED_POSITION);
-        List<String> errors = caseCloseService.validateReinstateClosedCaseMidEvent(caseData);
+        List<String> errors = CaseCloseValidator.validateReinstateClosedCaseMidEvent(caseData);
         assertEquals(1, errors.size());
         assertEquals(REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE, errors.get(0));
     }
@@ -40,7 +38,7 @@ class CaseCloseServiceTest {
     @Test
     void shouldValidateReinstateClosedCase_NotCaseClose_ReturnZero() {
         caseData.setPositionType("Awaiting ET3");
-        List<String> errors = caseCloseService.validateReinstateClosedCaseMidEvent(caseData);
+        List<String> errors = CaseCloseValidator.validateReinstateClosedCaseMidEvent(caseData);
         assertEquals(0, errors.size());
     }
 
@@ -48,7 +46,7 @@ class CaseCloseServiceTest {
     void shouldValidateBfActionsForCaseCloseEvent_AllCleared_Pass() {
         caseData.setBfActions(BFHelperTest.generateBFActionTypeItems());
         caseData.getBfActions().get(0).getValue().setCleared("2022-02-22");
-        List<String> errors = caseCloseService.validateBfActionsForCaseCloseEvent(caseData);
+        List<String> errors = CaseCloseValidator.validateBfActionsForCaseCloseEvent(caseData);
         assertEquals(0, errors.size());
     }
 
@@ -56,7 +54,7 @@ class CaseCloseServiceTest {
     void shouldValidateBfActionsForCaseCloseEvent_NotCleared_Error() {
         caseData.setBfActions(BFHelperTest.generateBFActionTypeItems());
         caseData.getBfActions().get(0).getValue().setCleared(null);
-        List<String> errors = caseCloseService.validateBfActionsForCaseCloseEvent(caseData);
+        List<String> errors = CaseCloseValidator.validateBfActionsForCaseCloseEvent(caseData);
         assertEquals(1, errors.size());
         assertEquals(CLOSING_CASE_WITH_BF_OPEN_ERROR, errors.get(0));
     }
@@ -64,7 +62,7 @@ class CaseCloseServiceTest {
     @Test
     void shouldValidateBfActionsForCaseCloseEvent_NoBF_Pass() {
         caseData.setBfActions(null);
-        List<String> errors = caseCloseService.validateBfActionsForCaseCloseEvent(caseData);
+        List<String> errors = CaseCloseValidator.validateBfActionsForCaseCloseEvent(caseData);
         assertEquals(0, errors.size());
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseCloseValidatorTest.java
@@ -17,7 +17,7 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.CASE_CLOSED_POSITIO
 import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator.CLOSING_CASE_WITH_BF_OPEN_ERROR;
 import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator.REINSTATE_CANNOT_CASE_CLOSED_ERROR_MESSAGE;
 
-class CaseCloseServiceTest {
+class CaseCloseValidatorTest {
 
     private CaseData caseData;
 
@@ -72,5 +72,4 @@ class CaseCloseServiceTest {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(json, CaseDetails.class);
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.ecm.common.model.ccd.types.CasePreAcceptType;
 import uk.gov.hmcts.ecm.common.model.ccd.types.JudgementType;
 import uk.gov.hmcts.ecm.common.model.listing.ListingRequest;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleData;
+import uk.gov.hmcts.ethos.replacement.docmosis.helpers.BFHelperTest;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -494,15 +495,13 @@ class EventValidationServiceTest {
         }
     }
 
-   // @ParameterizedTest
+    @ParameterizedTest
     @CsvSource({"false,false", "true,false", "false,true", "true,true"})
     void shouldValidateCaseBeforeCloseEventWithErrors(boolean isRejected, boolean partOfMultiple) {
         List<String> errors = new ArrayList<>();
 
-        List<String> msgBfActionsForCaseCloseEvent = new ArrayList<>();
-        msgBfActionsForCaseCloseEvent.add(CLOSING_CASE_WITH_BF_OPEN_ERROR);
-        when(CaseCloseValidator.validateBfActionsForCaseCloseEvent(caseDetails18.getCaseData()))
-                .thenReturn(msgBfActionsForCaseCloseEvent);
+        caseDetails18.getCaseData().setBfActions(BFHelperTest.generateBFActionTypeItems());
+        caseDetails18.getCaseData().getBfActions().get(0).getValue().setCleared(null);
 
         eventValidationService.validateCaseBeforeCloseEvent(caseDetails18.getCaseData(),
                 isRejected, partOfMultiple, errors);

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationServiceTest.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.UUID;
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,12 +10,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseDetails;
-import uk.gov.hmcts.ecm.common.model.ccd.items.DateListedTypeItem;
-import uk.gov.hmcts.ecm.common.model.ccd.items.HearingTypeItem;
 import uk.gov.hmcts.ecm.common.model.ccd.items.JudgementTypeItem;
 import uk.gov.hmcts.ecm.common.model.ccd.types.CasePreAcceptType;
-import uk.gov.hmcts.ecm.common.model.ccd.types.DateListedType;
-import uk.gov.hmcts.ecm.common.model.ccd.types.HearingType;
 import uk.gov.hmcts.ecm.common.model.ccd.types.JudgementType;
 import uk.gov.hmcts.ecm.common.model.listing.ListingRequest;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleData;
@@ -28,8 +22,12 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ACCEPTED_STATE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CASE_CLOSED_POSITION;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLOSED_STATE;
@@ -571,8 +569,6 @@ class EventValidationServiceTest {
         assertEquals(1, errors.size());
         assertEquals(JURISDICTION_CODES_EXISTENCE_ERROR + "ADG, COM", errors.get(0));
     }
-
-
 
     @Test
     void shouldValidateReportDateRangeValidDates() {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationServiceTest.java
@@ -57,13 +57,11 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.REJECTED_STATE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SINGLE_CASE_TYPE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SUBMITTED_STATE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.TARGET_HEARING_DATE_INCREMENT;
-import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseService.CLOSING_CASE_WITH_BF_OPEN_ERROR;
+import static uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator.CLOSING_CASE_WITH_BF_OPEN_ERROR;
 
 @ExtendWith(SpringExtension.class)
 class EventValidationServiceTest {
 
-    @Mock
-    private CaseCloseService caseCloseService;
     @InjectMocks
     private EventValidationService eventValidationService;
 
@@ -496,14 +494,14 @@ class EventValidationServiceTest {
         }
     }
 
-    @ParameterizedTest
+   // @ParameterizedTest
     @CsvSource({"false,false", "true,false", "false,true", "true,true"})
     void shouldValidateCaseBeforeCloseEventWithErrors(boolean isRejected, boolean partOfMultiple) {
         List<String> errors = new ArrayList<>();
 
         List<String> msgBfActionsForCaseCloseEvent = new ArrayList<>();
         msgBfActionsForCaseCloseEvent.add(CLOSING_CASE_WITH_BF_OPEN_ERROR);
-        when(caseCloseService.validateBfActionsForCaseCloseEvent(caseDetails18.getCaseData()))
+        when(CaseCloseValidator.validateBfActionsForCaseCloseEvent(caseDetails18.getCaseData()))
                 .thenReturn(msgBfActionsForCaseCloseEvent);
 
         eventValidationService.validateCaseBeforeCloseEvent(caseDetails18.getCaseData(),

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleCloseEventValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleCloseEventValidationServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.ecm.common.model.ccd.types.JudgementType;
 import uk.gov.hmcts.ecm.common.model.ccd.types.JurCodesType;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.MultipleUtil;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.EventValidationService;
 
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ public class MultipleCloseEventValidationServiceTest {
     @Before
     public void setUp() {
         multipleDetails = new MultipleDetails();
+        //eventValidationService = new EventValidationService(caseCloseService);
         multipleDetails.setCaseData(MultipleUtil.getMultipleData());
         errors = new ArrayList<>();
         userToken = "authString";

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleCloseEventValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/excel/MultipleCloseEventValidationServiceTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.ecm.common.model.ccd.types.JudgementType;
 import uk.gov.hmcts.ecm.common.model.ccd.types.JurCodesType;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.MultipleUtil;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseCloseValidator;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.EventValidationService;
 
 import java.util.ArrayList;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ECM-660

### Change description ###

add validation to the 'close case' action on single cases that stop the user being able to close the case if there is an outstanding/uncleared BF(s).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
