### PR TITLE
DocStore CDAM download case removed

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -212,4 +212,13 @@
         <packageUrl regex="true">^pkg:npm/got@.*$</packageUrl>
         <cve>1088948</cve>
     </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: woodstox-core-6.2.8.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.woodstox\/woodstox-core@.*$</packageUrl>
+        <cpe>cpe:2.3:a:fasterxml:woodstox</cpe>
+        <cve>CVE-2022-40152</cve>
+    </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -212,7 +212,6 @@
         <packageUrl regex="true">^pkg:npm/got@.*$</packageUrl>
         <cve>1088948</cve>
     </suppress>
-
     <suppress>
         <notes><![CDATA[
    file name: woodstox-core-6.2.8.jar
@@ -220,5 +219,9 @@
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.woodstox\/woodstox-core@.*$</packageUrl>
         <cpe>cpe:2.3:a:fasterxml:woodstox</cpe>
         <cve>CVE-2022-40152</cve>
+    </suppress>
+    <suppress>
+        <packageUrl regex="true">^pkg:npm/%40sideway%2Fformula@.*$</packageUrl>
+        <cve>1091026</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/DocumentManagementService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/DocumentManagementService.java
@@ -122,22 +122,15 @@ public class DocumentManagementService {
     public UploadedDocument downloadFile(String authToken, String urlString) {
         var user = userService.getUserDetails(authToken);
         ResponseEntity<Resource> response;
-        if (secureDocStoreEnabled) {
-            response = caseDocumentClient.getDocumentBinary(
-                    authToken,
-                    authTokenGenerator.generate(),
-                    getDocumentUUID(urlString)
-            );
 
-        } else {
-            response = documentDownloadClientApi.downloadBinary(
-                    authToken,
-                    authTokenGenerator.generate(),
-                    String.join(",", user.getRoles()),
-                    user.getUid(),
-                    getDownloadUrl(urlString)
-            );
-        }
+        response = documentDownloadClientApi.downloadBinary(
+                authToken,
+                authTokenGenerator.generate(),
+                String.join(",", user.getRoles()),
+                user.getUid(),
+                getDownloadUrl(urlString)
+        );
+
         if (HttpStatus.OK.equals(response.getStatusCode())) {
             return UploadedDocument.builder()
                     .content(response.getBody())

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/DocumentManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/DocumentManagementServiceTest.java
@@ -142,7 +142,7 @@ public class DocumentManagementServiceTest {
     @Test
     public void downloadFileSecureDocStoreTrue() {
         ReflectionTestUtils.setField(documentManagementService, "secureDocStoreEnabled", true);
-        when(caseDocumentClient.getDocumentBinary(anyString(), anyString(), anyString()))
+        when(documentDownloadClientApi.downloadBinary(anyString(), anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(responseEntity);
         UploadedDocument uploadedDocument = documentManagementService.downloadFile("authString",
                 "http://dm-store:8080/documents/85d97996-22a5-40d7-882e-3a382c8ae1b4/binary");


### PR DESCRIPTION
The CDAM download case removed and unit test adjusted.

Local test confirmed file upload and multiple case type creation work as far as feature.secure-doc-store.enabled is set to true. 

I have to deploy to demo and test it for file download as my local environment does not work.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
