### PR TITLE
ethos ref duplicate link update added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -272,7 +272,7 @@ dependencyManagement {
 
 dependencies {
 
-    implementation group: 'com.github.hmcts', name: 'ecm-common', version: '2.0.9'
+    implementation group: 'com.github.hmcts', name: 'ecm-common', version: '2.0.10'
     implementation group: 'com.github.hmcts', name: 'ecm-data-model', version: '1.3.4'
     implementation group: 'com.github.hmcts', name: 'et-data-model', version: '4.0.1'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -255,5 +255,12 @@
         <packageUrl regex="true">^pkg:npm/braces@.*$</packageUrl>
         <vulnerabilityName>GHSA-grv7-fg5c-xmjg</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: yarn.lock
+   ]]></notes>
+        <packageUrl regex="true">^pkg:npm/ws@.*$</packageUrl>
+        <vulnerabilityName>GHSA-3h5v-q93c-6h6q</vulnerabilityName>
+    </suppress>
 </suppressions>
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -412,11 +412,11 @@ public class CaseManagementForCaseWorkerService {
 
         // check if the duplicate case is the same as the source case by comparing the following fields:
         // ethos ref, respondent, claimant, submission ref(i.e. FeeGroupReference), and date of receipt
-        if (submitEvent != null && submitEvent.getCaseData() != null
+        if (caseData != null
+                && submitEvent != null && submitEvent.getCaseData() != null
                 && !isTransferredCase(submitEvent)) {
             CaseData targetCaseData = submitEvent.getCaseData();
-            if (targetCaseData != null
-                    && caseData.getEthosCaseReference().equals(targetCaseData.getEthosCaseReference())
+            if (caseData.getEthosCaseReference().equals(targetCaseData.getEthosCaseReference())
                     && caseData.getClaimant().equals(targetCaseData.getClaimant())
                     && caseData.getRespondent().equals(targetCaseData.getRespondent())
                     && caseData.getFeeGroupReference().equals(targetCaseData.getFeeGroupReference())) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -367,16 +367,16 @@ public class CaseManagementForCaseWorkerService {
     public void setMigratedCaseLinkDetails(String authToken, CaseDetails caseDetails) {
         // get a target case data using the source case data and
         // elastic search query
-        List<Pair<String, List<SubmitEvent>>> listOfCaseTypeIdAndCaseDataPair =
+        List<Pair<String, List<SubmitEvent>>> listOfCaseTypeIdAndCaseDataPairsList =
                 caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(caseDetails.getCaseId(),
                         caseDetails.getCaseTypeId(), authToken, caseTypeIdsToCheck);
         // For the first round, update only by referring & validating single duplicates, i.e. ethos reference
         // similar to the current update target case
-        if (listOfCaseTypeIdAndCaseDataPair == null || listOfCaseTypeIdAndCaseDataPair.size() != 1) {
+        if (!isValidListOfPairs(listOfCaseTypeIdAndCaseDataPairsList)) {
             return;
         }
-        String sourceCaseTypeId = listOfCaseTypeIdAndCaseDataPair.get(0).getFirst();
-        SubmitEvent submitEvent = listOfCaseTypeIdAndCaseDataPair.get(0).getSecond().get(0);
+        String sourceCaseTypeId = listOfCaseTypeIdAndCaseDataPairsList.get(0).getFirst();
+        SubmitEvent submitEvent = listOfCaseTypeIdAndCaseDataPairsList.get(0).getSecond().get(0);
 
         if (isValidDuplicateCase(submitEvent, caseDetails.getCaseData())) {
             log.info("SubmitEvent retrieved from ES for the update target case: {} with source case type of {}.",
@@ -393,6 +393,12 @@ public class CaseManagementForCaseWorkerService {
                         + ethosCaseReference + "</a>");
             }
         }
+    }
+
+    private boolean isValidListOfPairs(List<Pair<String, List<SubmitEvent>>>
+                                                                    listOfCaseTypeIdAndCaseDataPairsList) {
+        return listOfCaseTypeIdAndCaseDataPairsList != null
+                && listOfCaseTypeIdAndCaseDataPairsList.size() == 1;
     }
 
     private boolean isTransferredCase(SubmitEvent submitEvent) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -378,44 +378,43 @@ public class CaseManagementForCaseWorkerService {
         String sourceCaseTypeId = listOfCaseTypeIdAndCaseDataPair.get(0).getFirst();
         SubmitEvent submitEvent = listOfCaseTypeIdAndCaseDataPair.get(0).getSecond().get(0);
 
-        //check if the source case is not of a transferred state
-        if (!isTransferredCase(submitEvent)) {
-            if (isValidDuplicateCase(submitEvent, caseDetails.getCaseData())) {
-                log.info("SubmitEvent retrieved from ES for the update target case: {} with source case type of {}.",
-                        submitEvent.getCaseId(), sourceCaseTypeId);
-                String sourceCaseId = String.valueOf(submitEvent.getCaseId());
-                String ethosCaseReference = caseRetrievalForCaseWorkerService.caseRefRetrievalRequest(authToken,
-                        sourceCaseTypeId, EMPLOYMENT_JURISDICTION, sourceCaseId);
-                log.info("Source Case reference is retrieved via retrieveTransferredCaseReference: {}.",
-                        ethosCaseReference);
+        if (isValidDuplicateCase(submitEvent, caseDetails.getCaseData())) {
+            log.info("SubmitEvent retrieved from ES for the update target case: {} with source case type of {}.",
+                    submitEvent.getCaseId(), sourceCaseTypeId);
+            String sourceCaseId = String.valueOf(submitEvent.getCaseId());
+            String ethosCaseReference = caseRetrievalForCaseWorkerService.caseRefRetrievalRequest(authToken,
+                    sourceCaseTypeId, EMPLOYMENT_JURISDICTION, sourceCaseId);
+            log.info("Source Case reference is retrieved via retrieveTransferredCaseReference: {}.",
+                    ethosCaseReference);
 
-                if (ethosCaseReference != null) {
-                    caseDetails.getCaseData().setTransferredCaseLink("<a target=\"_blank\" href=\""
-                            + String.format("%s/cases/case-details/%s", ccdGatewayBaseUrl, sourceCaseId) + "\">"
-                            + ethosCaseReference + "</a>");
-                }
+            if (ethosCaseReference != null) {
+                caseDetails.getCaseData().setTransferredCaseLink("<a target=\"_blank\" href=\""
+                        + String.format("%s/cases/case-details/%s", ccdGatewayBaseUrl, sourceCaseId) + "\">"
+                        + ethosCaseReference + "</a>");
             }
         }
     }
 
     private boolean isTransferredCase(SubmitEvent submitEvent) {
+        //check if the source case is not of a transferred state
         return submitEvent != null && submitEvent.getState() != null
                 && TRANSFERRED.equals(submitEvent.getState());
     }
 
     private boolean isValidDuplicateCase(SubmitEvent submitEvent, CaseData caseData) {
         boolean isValidationDuplicate = false;
+
         // check if the duplicate case is the same as the source case by comparing the following fields:
         // ethos ref, respondent, claimant, submission ref(i.e. FeeGroupReference), and date of receipt
-        if (submitEvent != null && submitEvent.getCaseData() != null) {
+        if (submitEvent != null && submitEvent.getCaseData() != null
+                && !isTransferredCase(submitEvent)) {
             CaseData targetCaseData = submitEvent.getCaseData();
-            if (targetCaseData != null) {
-                if (caseData.getEthosCaseReference().equals(targetCaseData.getEthosCaseReference())
-                        && caseData.getClaimant().equals(targetCaseData.getClaimant())
-                        && caseData.getRespondent().equals(targetCaseData.getRespondent())
-                        && caseData.getFeeGroupReference().equals(targetCaseData.getFeeGroupReference())) {
-                    isValidationDuplicate = true;
-                }
+            if (targetCaseData != null
+                    && caseData.getEthosCaseReference().equals(targetCaseData.getEthosCaseReference())
+                    && caseData.getClaimant().equals(targetCaseData.getClaimant())
+                    && caseData.getRespondent().equals(targetCaseData.getRespondent())
+                    && caseData.getFeeGroupReference().equals(targetCaseData.getFeeGroupReference())) {
+                isValidationDuplicate = true;
             }
         }
         return isValidationDuplicate;

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -408,7 +408,7 @@ public class CaseManagementForCaseWorkerService {
     }
 
     private boolean isValidDuplicateCase(SubmitEvent submitEvent, CaseData caseData) {
-        boolean isValidationDuplicate = false;
+        boolean isValidDuplicate = false;
 
         // check if the duplicate case is the same as the source case by comparing the following fields:
         // ethos ref, respondent, claimant, submission ref(i.e. FeeGroupReference), and date of receipt
@@ -420,10 +420,10 @@ public class CaseManagementForCaseWorkerService {
                     && caseData.getClaimant().equals(targetCaseData.getClaimant())
                     && caseData.getRespondent().equals(targetCaseData.getRespondent())
                     && caseData.getFeeGroupReference().equals(targetCaseData.getFeeGroupReference())) {
-                isValidationDuplicate = true;
+                isValidDuplicate = true;
             }
         }
-        return isValidationDuplicate;
+        return isValidDuplicate;
     }
 
     public void amendRespondentNameRepresentativeNames(CaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -412,18 +412,26 @@ public class CaseManagementForCaseWorkerService {
 
         // check if the duplicate case is the same as the source case by comparing the following fields:
         // ethos ref, respondent, claimant, submission ref(i.e. FeeGroupReference), and date of receipt
-        if (caseData != null
-                && submitEvent != null && submitEvent.getCaseData() != null
-                && !isTransferredCase(submitEvent)) {
-            CaseData targetCaseData = submitEvent.getCaseData();
-            if (caseData.getEthosCaseReference().equals(targetCaseData.getEthosCaseReference())
-                    && caseData.getClaimant().equals(targetCaseData.getClaimant())
-                    && caseData.getRespondent().equals(targetCaseData.getRespondent())
-                    && caseData.getFeeGroupReference().equals(targetCaseData.getFeeGroupReference())) {
-                isValidDuplicate = true;
-            }
+        if (caseData == null || submitEvent == null || submitEvent.getCaseData() == null) {
+            return isValidDuplicate;
         }
+
+        CaseData targetCaseData = submitEvent.getCaseData();
+        if (!isTransferredCase(submitEvent) && haveSameCheckedFieldValues(caseData, targetCaseData)) {
+            isValidDuplicate = true;
+        }
+
         return isValidDuplicate;
+    }
+
+    // Checked field values : ethos ref, respondent, claimant, submission ref(i.e. FeeGroupReference),
+    // and date of receipt
+    private boolean haveSameCheckedFieldValues(CaseData caseData, CaseData targetCaseData) {
+        return caseData.getEthosCaseReference().equals(targetCaseData.getEthosCaseReference())
+                && caseData.getClaimant().equals(targetCaseData.getClaimant())
+                && caseData.getRespondent().equals(targetCaseData.getRespondent())
+                && caseData.getFeeGroupReference().equals(targetCaseData.getFeeGroupReference())
+                && caseData.getReceiptDate().equals(targetCaseData.getReceiptDate());
     }
 
     public void amendRespondentNameRepresentativeNames(CaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerService.java
@@ -18,7 +18,8 @@ import java.util.List;
 public class CaseRetrievalForCaseWorkerService {
 
     private static final String MESSAGE = "Failed to retrieve case for : ";
-    private static final String EMPTY_STRING = "";
+    private static final String ETHOS_REF_DUPLICATES_RETRIEVAL_ERROR_MESSAGE =
+            "Failed to retrieve cases with duplicate Ethos ref for : ";
     private final CcdClient ccdClient;
 
     @Autowired
@@ -62,21 +63,24 @@ public class CaseRetrievalForCaseWorkerService {
         }
     }
 
-    public Pair<String, List<SubmitEvent>> transferSourceCaseRetrievalESRequest(String currentCaseId, String authToken,
-                                                              List<String> caseTypeIdsToCheck) {
+    public List<Pair<String, List<SubmitEvent>>>  transferSourceCaseRetrievalESRequest(
+            String currentCaseId, String currentCaseTypeId, String authToken, List<String> caseTypeIdsToCheck) {
+        List<Pair<String, List<SubmitEvent>>> listOfParis = new ArrayList<>();
         try {
             for (String targetOffice : caseTypeIdsToCheck) {
+                if (currentCaseTypeId.equals(targetOffice)) {
+                    continue;
+                }
                 List<SubmitEvent> submitEvents = ccdClient.retrieveTransferredCaseElasticSearch(authToken,
                         targetOffice, currentCaseId);
                 if (!submitEvents.isEmpty()) {
-                    return Pair.of(targetOffice, submitEvents);
+                    listOfParis.add(Pair.of(targetOffice, submitEvents));
                 }
             }
-
-            return Pair.of(EMPTY_STRING, new ArrayList<>());
+            return listOfParis;
         } catch (Exception ex) {
-            throw new CaseRetrievalException(MESSAGE + currentCaseId + ex.getMessage());
+            throw new CaseRetrievalException(ETHOS_REF_DUPLICATES_RETRIEVAL_ERROR_MESSAGE
+                    + currentCaseId + ex.getMessage());
         }
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -1015,6 +1015,7 @@ class CaseManagementForCaseWorkerServiceTest {
         caseData.setClaimant("testClaimant");
         caseData.setRespondent("testRespondent");
         caseData.setFeeGroupReference("testFeeGroupReference");
+        caseData.setReceiptDate("2024-03-12");
         caseDetails.setCaseData(caseData);
         return caseDetails;
     }
@@ -1027,6 +1028,7 @@ class CaseManagementForCaseWorkerServiceTest {
         caseData.setClaimant("testClaimant");
         caseData.setRespondent("testRespondent");
         caseData.setFeeGroupReference("testFeeGroupReference");
+        caseData.setReceiptDate("2024-03-12");
         submitEvent.setCaseData(caseData);
         submitEvent.setState("Accepted");
         return submitEvent;

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -1039,6 +1039,32 @@ class CaseManagementForCaseWorkerServiceTest {
     }
 
     @Test
+    void testSetMigratedCaseLinkDetails_When_CaseRefAndCaseDataPairIsNotOne() {
+        List<Pair<String, List<SubmitEvent>>> listOfCaseTypeIdAndCaseDataPair = new ArrayList<>();
+        listOfCaseTypeIdAndCaseDataPair.add(Pair.of("Leeds", List.of(submitEvent)));
+        SubmitEvent newcastleSubmitEvent = new SubmitEvent();
+        CaseData newcastlCaseCaseData = new CaseData();
+        newcastlCaseCaseData.setEthosCaseReference("EthosCaseRef");
+        newcastleSubmitEvent.setCaseData(newcastlCaseCaseData);
+        listOfCaseTypeIdAndCaseDataPair.add(Pair.of("Newcastle", List.of(newcastleSubmitEvent)));
+
+        String authToken = "authToken";
+        String caseId = "caseId";
+        String caseTypeId = "Leeds";
+        CaseDetails caseDetails = new CaseDetails();
+        CaseData caseData = new CaseData();
+        caseData.setCcdID(caseId);
+        caseDetails.setCaseData(caseData);
+        when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
+                caseId, caseTypeId, authToken, List.of("Leeds"))).thenReturn(listOfCaseTypeIdAndCaseDataPair);
+        when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
+                caseId, caseTypeId, authToken, List.of("Leeds"))).thenReturn(null);
+
+        caseManagementForCaseWorkerService.setMigratedCaseLinkDetails(authToken, caseDetails);
+        assertNull(caseDetails.getCaseData().getTransferredCaseLink());
+    }
+
+    @Test
     void testSetMigratedCaseLinkDetails_When_SubmitEventList_IsEmpty() {
         String authToken = "authToken";
         String caseId = "caseId";
@@ -1106,7 +1132,7 @@ class CaseManagementForCaseWorkerServiceTest {
         caseDataOne.setCcdID("889900");
         submitEventFour.setCaseData(caseDataOne);
         submitEventFour.setState("Transferred");
-        
+
         when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),
                 anyString(), anyList())).thenReturn(List.of(Pair.of("testSourceCaseType",
                 List.of(submitEventFour))));

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -62,6 +62,8 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ABERDEEN_OFFICE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ABOUT_TO_SUBMIT_EVENT_CALLBACK;
@@ -1004,6 +1006,12 @@ class CaseManagementForCaseWorkerServiceTest {
         assertEquals("<a target=\"_blank\" href=\"" + ccdGatewayBaseUrl + "/cases/case-details/"
                 + submitEventLocal.getCaseId() + "\">EthosCaseRef</a>",
                 caseDetails.getCaseData().getTransferredCaseLink());
+        assertEquals("testClaimant", caseDetails.getCaseData().getClaimant());
+        assertEquals("testRespondent", caseDetails.getCaseData().getRespondent());
+        assertEquals("testFeeGroupReference", caseDetails.getCaseData().getFeeGroupReference());
+        verify(caseRetrievalForCaseWorkerService,
+                times(1)).transferSourceCaseRetrievalESRequest(anyString(),
+                anyString(), anyString(), anyList());
     }
 
     private static @NotNull CaseDetails getCaseDetails() {
@@ -1036,6 +1044,9 @@ class CaseManagementForCaseWorkerServiceTest {
                 caseId, caseTypeId, authToken, List.of("Leeds"))).thenReturn(null);
         caseManagementForCaseWorkerService.setMigratedCaseLinkDetails(authToken, caseDetails);
         assertNull(caseDetails.getCaseData().getTransferredCaseLink());
+        verify(caseRetrievalForCaseWorkerService,
+                times(0)).transferSourceCaseRetrievalESRequest(
+                        anyString(), anyString(), anyString(), anyList());
     }
 
     @Test
@@ -1126,7 +1137,7 @@ class CaseManagementForCaseWorkerServiceTest {
     }
 
     @Test
-    void testSetMigratedCaseLinkDetails_InvalidDuplicateCases() {
+    void testSetMigratedCaseLinkDetails_InvalidDuplicateCases_Transferred() {
         SubmitEvent submitEventFour = new SubmitEvent();
         CaseData caseDataOne = new CaseData();
         caseDataOne.setCcdID("889900");

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -1006,6 +1006,7 @@ class CaseManagementForCaseWorkerServiceTest {
         assertEquals("<a target=\"_blank\" href=\"" + ccdGatewayBaseUrl + "/cases/case-details/"
                 + submitEventLocal.getCaseId() + "\">EthosCaseRef</a>",
                 caseDetails.getCaseData().getTransferredCaseLink());
+        assertEquals("EthosCaseRef", caseDetails.getCaseData().getEthosCaseReference());
         assertEquals("testClaimant", caseDetails.getCaseData().getClaimant());
         assertEquals("testRespondent", caseDetails.getCaseData().getRespondent());
         assertEquals("testFeeGroupReference", caseDetails.getCaseData().getFeeGroupReference());
@@ -1143,6 +1144,25 @@ class CaseManagementForCaseWorkerServiceTest {
         caseDataOne.setCcdID("889900");
         submitEventFour.setCaseData(caseDataOne);
         submitEventFour.setState("Transferred");
+
+        when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),
+                anyString(), anyList())).thenReturn(List.of(Pair.of("testSourceCaseType",
+                List.of(submitEventFour))));
+
+        CaseDetails caseDetails = new CaseDetails();
+        caseDetails.setCaseId("456");
+        CaseData caseData = new CaseData();
+        caseData.setCcdID("2277");
+        caseDetails.setCaseData(caseData);
+        caseManagementForCaseWorkerService.setMigratedCaseLinkDetails("authToken", caseDetails);
+
+        assertNull(caseDetails.getCaseData().getTransferredCaseLink());
+    }
+
+    @Test
+    void testSetMigratedCaseLinkDetails_InvalidDuplicateCases_Null_SubmitEvent_Casedata() {
+        SubmitEvent submitEventFour = new SubmitEvent();
+        submitEventFour.setCaseData(null);
 
         when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),
                 anyString(), anyList())).thenReturn(List.of(Pair.of("testSourceCaseType",

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -1058,12 +1058,12 @@ class CaseManagementForCaseWorkerServiceTest {
     @Test
     void testSetMigratedCaseLinkDetails_EmptySourceCaseTypeId() {
         when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),
-                anyString(), anyList())).thenReturn(List.of(Pair.of("testSourceCaseType", new ArrayList<>())));
+                anyString(), anyList())).thenReturn(List.of(Pair.of("testSourceCaseTypeId", new ArrayList<>())));
 
         CaseDetails caseDetails = new CaseDetails();
-        caseDetails.setCaseId("123");
+        caseDetails.setCaseId("14423");
         CaseData caseData = new CaseData();
-        caseData.setCcdID("67777");
+        caseData.setCcdID("89987");
         caseDetails.setCaseData(caseData);
         caseManagementForCaseWorkerService.setMigratedCaseLinkDetails("authToken", caseDetails);
         assertNull(caseDetails.getCaseData().getTransferredCaseLink());
@@ -1072,7 +1072,7 @@ class CaseManagementForCaseWorkerServiceTest {
     @Test
     void testSetMigratedCaseLinkDetails_NullSourceCase() {
         when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),
-                anyString(), anyList())).thenReturn(List.of(Pair.of("testSourceCaseType", new ArrayList<>())));
+                anyString(), anyList())).thenReturn(List.of(Pair.of("testNullSourceCase", new ArrayList<>())));
 
         CaseDetails caseDetails = new CaseDetails();
         caseDetails.setCaseId("123");

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -1096,9 +1096,31 @@ class CaseManagementForCaseWorkerServiceTest {
         caseData.setCcdID("2277");
         caseDetails.setCaseData(caseData);
         caseManagementForCaseWorkerService.setMigratedCaseLinkDetails("authToken", caseDetails);
+        assertNull(caseDetails.getCaseData().getTransferredCaseLink());
+    }
+
+    @Test
+    void testSetMigratedCaseLinkDetails_InvalidDuplicateCases() {
+        SubmitEvent submitEventFour = new SubmitEvent();
+        CaseData caseDataOne = new CaseData();
+        caseDataOne.setCcdID("889900");
+        submitEventFour.setCaseData(caseDataOne);
+        submitEventFour.setState("Transferred");
+        
+        when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),
+                anyString(), anyList())).thenReturn(List.of(Pair.of("testSourceCaseType",
+                List.of(submitEventFour))));
+
+        CaseDetails caseDetails = new CaseDetails();
+        caseDetails.setCaseId("456");
+        CaseData caseData = new CaseData();
+        caseData.setCcdID("2277");
+        caseDetails.setCaseData(caseData);
+        caseManagementForCaseWorkerService.setMigratedCaseLinkDetails("authToken", caseDetails);
 
         assertNull(caseDetails.getCaseData().getTransferredCaseLink());
     }
+
     @Test
     void testSetMigratedCaseLinkDetails_When_EthosCaseReferenceIsNull() {
         String authToken = "authToken";

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -1050,9 +1050,10 @@ class CaseManagementForCaseWorkerServiceTest {
     }
 
     @Test
-    void testSetMigratedCaseLinkDetails_When_CaseRefAndCaseDataPairIsNotOne() {
+    void testSetMigratedCaseLinkDetails_When_CaseRefAndCaseDataPairList_Size_NotEqualTo_One() {
         List<Pair<String, List<SubmitEvent>>> listOfCaseTypeIdAndCaseDataPair = new ArrayList<>();
         listOfCaseTypeIdAndCaseDataPair.add(Pair.of("Leeds", List.of(submitEvent)));
+
         SubmitEvent newcastleSubmitEvent = new SubmitEvent();
         CaseData newcastlCaseCaseData = new CaseData();
         newcastlCaseCaseData.setEthosCaseReference("EthosCaseRef");
@@ -1068,11 +1069,11 @@ class CaseManagementForCaseWorkerServiceTest {
         caseDetails.setCaseData(caseData);
         when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
                 caseId, caseTypeId, authToken, List.of("Leeds"))).thenReturn(listOfCaseTypeIdAndCaseDataPair);
-        when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
-                caseId, caseTypeId, authToken, List.of("Leeds"))).thenReturn(null);
 
         caseManagementForCaseWorkerService.setMigratedCaseLinkDetails(authToken, caseDetails);
         assertNull(caseDetails.getCaseData().getTransferredCaseLink());
+        verify(caseRetrievalForCaseWorkerService,times(0)).caseRefRetrievalRequest(
+                anyString(), anyString(), anyString(), anyString());
     }
 
     @Test
@@ -1107,21 +1108,7 @@ class CaseManagementForCaseWorkerServiceTest {
     }
 
     @Test
-    void testSetMigratedCaseLinkDetails_NullSourceCase() {
-        when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),
-                anyString(), anyList())).thenReturn(List.of(Pair.of("testNullSourceCase", new ArrayList<>())));
-
-        CaseDetails caseDetails = new CaseDetails();
-        caseDetails.setCaseId("123");
-        CaseData caseData = new CaseData();
-        caseData.setCcdID("67777");
-        caseDetails.setCaseData(caseData);
-        caseManagementForCaseWorkerService.setMigratedCaseLinkDetails("authToken", caseDetails);
-        assertNull(caseDetails.getCaseData().getTransferredCaseLink());
-    }
-
-    @Test
-    void testSetMigratedCaseLinkDetails_NullCaseData() {
+    void testSetMigratedCaseLinkDetails_NullSourceCaseData() {
         SubmitEvent submitEventFour = new SubmitEvent();
         submitEventFour.setCaseData(null);
         when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -1010,9 +1010,10 @@ class CaseManagementForCaseWorkerServiceTest {
         assertEquals("testClaimant", caseDetails.getCaseData().getClaimant());
         assertEquals("testRespondent", caseDetails.getCaseData().getRespondent());
         assertEquals("testFeeGroupReference", caseDetails.getCaseData().getFeeGroupReference());
-        verify(caseRetrievalForCaseWorkerService,
-                times(1)).transferSourceCaseRetrievalESRequest(anyString(),
-                anyString(), anyString(), anyList());
+        verify(caseRetrievalForCaseWorkerService, times(1))
+                .transferSourceCaseRetrievalESRequest(anyString(), anyString(), anyString(), anyList());
+        verify(caseRetrievalForCaseWorkerService,times(1)).caseRefRetrievalRequest(
+                anyString(), anyString(), anyString(), anyString());
     }
 
     private static @NotNull CaseDetails getCaseDetails() {
@@ -1035,19 +1036,17 @@ class CaseManagementForCaseWorkerServiceTest {
     void testSetMigratedCaseLinkDetails_When_CaseRefAndCaseDataPairIsNull() {
         String authToken = "authToken";
         String caseId = "caseId";
-        String caseTypeId = "Leeds";
         CaseDetails caseDetails = new CaseDetails();
         CaseData caseData = new CaseData();
         caseData.setCcdID(caseId);
         caseDetails.setCaseData(caseData);
 
         when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
-                caseId, caseTypeId, authToken, List.of("Leeds"))).thenReturn(null);
+                anyString(), anyString(), anyString(), anyList())).thenReturn(null);
         caseManagementForCaseWorkerService.setMigratedCaseLinkDetails(authToken, caseDetails);
         assertNull(caseDetails.getCaseData().getTransferredCaseLink());
-        verify(caseRetrievalForCaseWorkerService,
-                times(0)).transferSourceCaseRetrievalESRequest(
-                        anyString(), anyString(), anyString(), anyList());
+        verify(caseRetrievalForCaseWorkerService,times(0)).caseRefRetrievalRequest(
+                anyString(), anyString(), anyString(), anyString());
     }
 
     @Test
@@ -1160,25 +1159,6 @@ class CaseManagementForCaseWorkerServiceTest {
     }
 
     @Test
-    void testSetMigratedCaseLinkDetails_InvalidDuplicateCases_Null_SubmitEvent_Casedata() {
-        SubmitEvent submitEventFour = new SubmitEvent();
-        submitEventFour.setCaseData(null);
-
-        when(caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(anyString(), anyString(),
-                anyString(), anyList())).thenReturn(List.of(Pair.of("testSourceCaseType",
-                List.of(submitEventFour))));
-
-        CaseDetails caseDetails = new CaseDetails();
-        caseDetails.setCaseId("456");
-        CaseData caseData = new CaseData();
-        caseData.setCcdID("2277");
-        caseDetails.setCaseData(caseData);
-        caseManagementForCaseWorkerService.setMigratedCaseLinkDetails("authToken", caseDetails);
-
-        assertNull(caseDetails.getCaseData().getTransferredCaseLink());
-    }
-
-    @Test
     void testSetMigratedCaseLinkDetails_When_EthosCaseReferenceIsNull() {
         String authToken = "authToken";
         String caseId = "caseId";
@@ -1202,9 +1182,7 @@ class CaseManagementForCaseWorkerServiceTest {
         when(caseRetrievalForCaseWorkerService.caseRetrievalRequest(
                 authToken, "caseTypeId", EMPLOYMENT_JURISDICTION, "12345"))
                 .thenReturn(fullSourceCase);
-
         caseManagementForCaseWorkerService.setMigratedCaseLinkDetails(authToken, caseDetails);
-
         assertNull(caseDetails.getCaseData().getTransferredCaseLink());
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerServiceTest.java
@@ -152,15 +152,15 @@ public class CaseRetrievalForCaseWorkerServiceTest {
     @Test
     public void testTransferSourceCaseRetrievalESRequestContinue() throws IOException {
         String currentCaseId = "123456";
-        SubmitEvent submitEvent = getSubmitEvent();
+        SubmitEvent submitEventLocal = getSubmitEvent();
         when(ccdClient.retrieveTransferredCaseElasticSearch(any(), any(), any()))
-                .thenReturn(List.of(submitEvent));
+                .thenReturn(List.of(submitEventLocal));
         List<Pair<String, List<SubmitEvent>>> result =
                 caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
                         currentCaseId, "Newcastle", AUTH_TOKEN,
                         List.of("Leeds", "Newcastle", "Manchester"));
 
-        assertEquals(submitEvent, result.get(0).getSecond().get(0));
+        assertEquals(submitEventLocal, result.get(0).getSecond().get(0));
         assertEquals("Leeds", result.get(0).getFirst());
         verify(ccdClient, times(0)).retrieveTransferredCaseElasticSearch(
                 AUTH_TOKEN, "Newcastle", currentCaseId);

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerServiceTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -29,8 +28,7 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class CaseRetrievalForCaseWorkerServiceTest {
-    private static final String EMPTY_STRING = "";
-    @InjectMocks
+     @InjectMocks
     private CaseRetrievalForCaseWorkerService caseRetrievalForCaseWorkerService;
     @Mock
     private CcdClient ccdClient;
@@ -102,11 +100,12 @@ public class CaseRetrievalForCaseWorkerServiceTest {
         SubmitEvent submitEvent = getSubmitEvent();
         when(ccdClient.retrieveTransferredCaseElasticSearch(any(), any(), any()))
                 .thenReturn(List.of(submitEvent));
-        Pair<String, List<SubmitEvent>> result = caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(currentCaseId,
-                authToken, List.of("Leeds"));
+        List<Pair<String, List<SubmitEvent>>> result =
+                caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
+                        currentCaseId, "Newcastle", authToken, List.of("Leeds"));
 
-        assertEquals(submitEvent, result.getSecond().get(0));
-        assertEquals("Leeds", result.getFirst());
+        assertEquals(submitEvent, result.get(0).getSecond().get(0));
+        assertEquals("Leeds", result.get(0).getFirst());
     }
 
     @Test
@@ -115,11 +114,11 @@ public class CaseRetrievalForCaseWorkerServiceTest {
         String authToken = "authToken";
         SubmitEvent submitEvent = getSubmitEvent();
         when(ccdClient.retrieveTransferredCaseElasticSearch(any(), any(), any())).thenReturn(List.of(submitEvent));
-        Pair<String, List<SubmitEvent>> result = caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
-                currentCaseId, authToken, new ArrayList<>());
+        List<Pair<String, List<SubmitEvent>>> result =
+                caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
+                        currentCaseId, "Newcastle", authToken, new ArrayList<>());
         assertNotNull(result);
-        assertEquals(EMPTY_STRING, result.getFirst());
-        assertTrue(result.getSecond().isEmpty());
+        assertEquals(result.size(), 0);
     }
 
     @Test(expected = Exception.class)
@@ -130,7 +129,7 @@ public class CaseRetrievalForCaseWorkerServiceTest {
         when(ccdClient.retrieveTransferredCaseElasticSearch(any(), any(), any()))
                 .thenReturn(List.of(submitEvent));
         caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(currentCaseId,
-                authToken, null);
+                "Newcastle", authToken, null);
     }
 
     private SubmitEvent getSubmitEvent() {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.springframework.data.util.Pair;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.hmcts.ecm.common.client.CcdClient;
+import uk.gov.hmcts.ecm.common.exceptions.CaseCreationException;
 import uk.gov.hmcts.ecm.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseDetails;
@@ -21,8 +22,12 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ERROR_MESSAGE;
 
@@ -34,7 +39,8 @@ public class CaseRetrievalForCaseWorkerServiceTest {
     private CcdClient ccdClient;
     private CCDRequest ccdRequest;
     private SubmitEvent submitEvent;
-
+    private static final String AUTH_TOKEN = "authToken";
+    private static final String MESSAGE = "Failed to retrieve case for : ";
     @Before
     public void setUp() {
         CaseDetails caseDetails;
@@ -50,14 +56,14 @@ public class CaseRetrievalForCaseWorkerServiceTest {
     @Test(expected = Exception.class)
     public void caseRetrievalRequestException() throws IOException {
         when(ccdClient.retrieveCase(anyString(), anyString(), anyString(), any())).thenThrow(new InternalException(ERROR_MESSAGE));
-        caseRetrievalForCaseWorkerService.caseRetrievalRequest("authToken", ccdRequest.getCaseDetails().getCaseTypeId(),
+        caseRetrievalForCaseWorkerService.caseRetrievalRequest(AUTH_TOKEN, ccdRequest.getCaseDetails().getCaseTypeId(),
                 ccdRequest.getCaseDetails().getJurisdiction(), "11111");
     }
 
     @Test
     public void caseRetrievalRequest() throws IOException {
         when(ccdClient.retrieveCase(anyString(), anyString(), anyString(), any())).thenReturn(submitEvent);
-        SubmitEvent submitEvent1 = caseRetrievalForCaseWorkerService.caseRetrievalRequest("authToken",
+        SubmitEvent submitEvent1 = caseRetrievalForCaseWorkerService.caseRetrievalRequest(AUTH_TOKEN,
                 ccdRequest.getCaseDetails().getCaseTypeId(), ccdRequest.getCaseDetails().getJurisdiction(), "11111");
         assertEquals(submitEvent, submitEvent1);
     }
@@ -65,21 +71,22 @@ public class CaseRetrievalForCaseWorkerServiceTest {
     @Test(expected = Exception.class)
     public void casesRetrievalRequestException() throws IOException {
         when(ccdClient.retrieveCases(anyString(), any(), any())).thenThrow(new InternalException(ERROR_MESSAGE));
-        caseRetrievalForCaseWorkerService.casesRetrievalRequest(ccdRequest, "authToken");
+        caseRetrievalForCaseWorkerService.casesRetrievalRequest(ccdRequest, AUTH_TOKEN);
     }
 
     @Test
     public void casesRetrievalRequest() throws IOException {
         List<SubmitEvent> submitEventList = Collections.singletonList(submitEvent);
         when(ccdClient.retrieveCases(anyString(), any(), any())).thenReturn(submitEventList);
-        List<SubmitEvent> submitEventList1 = caseRetrievalForCaseWorkerService.casesRetrievalRequest(ccdRequest, "authToken");
+        List<SubmitEvent> submitEventList1 = caseRetrievalForCaseWorkerService.casesRetrievalRequest(ccdRequest,
+                AUTH_TOKEN);
         assertEquals(submitEventList, submitEventList1);
     }
 
     @Test(expected = Exception.class)
     public void casesRetrievalESRequestException() throws IOException {
         when(ccdClient.retrieveCasesElasticSearch(anyString(), anyString(), any())).thenThrow(new InternalException(ERROR_MESSAGE));
-        caseRetrievalForCaseWorkerService.casesRetrievalESRequest("1111", "authToken",
+        caseRetrievalForCaseWorkerService.casesRetrievalESRequest("1111", AUTH_TOKEN,
                 ccdRequest.getCaseDetails().getCaseTypeId(), new ArrayList<>(Collections.singleton("1")));
     }
 
@@ -87,22 +94,56 @@ public class CaseRetrievalForCaseWorkerServiceTest {
     public void casesRetrievalESRequest() throws IOException {
         List<SubmitEvent> submitEventList = Collections.singletonList(submitEvent);
         when(ccdClient.retrieveCasesElasticSearch(anyString(), anyString(), any())).thenReturn(submitEventList);
-        List<SubmitEvent> submitEventList1 = caseRetrievalForCaseWorkerService.casesRetrievalESRequest("1111", "authToken",
-                ccdRequest.getCaseDetails().getCaseTypeId(), new ArrayList<>(Collections.singleton("1")));
+        List<SubmitEvent> submitEventList1 = caseRetrievalForCaseWorkerService.casesRetrievalESRequest(
+                "1111", AUTH_TOKEN, ccdRequest.getCaseDetails().getCaseTypeId(),
+                new ArrayList<>(Collections.singleton("1")));
         assertEquals(submitEventList, submitEventList1);
+    }
+
+    @Test
+    public void testCaseRefRetrievalRequest_Success() throws Exception {
+        String ethosCaseReference = "R5000656/2020";
+        String currentCaseId = "123456";
+        when(ccdClient.retrieveTransferredCaseReference(any(), any(), any(), any()))
+                .thenReturn(ethosCaseReference);
+
+        String result = caseRetrievalForCaseWorkerService.caseRefRetrievalRequest(
+                AUTH_TOKEN, "Newcastle", "EMPLOYMENT", currentCaseId);
+
+        // Assert
+        assertEquals(ethosCaseReference, result);
+        verify(ccdClient, times(1)).retrieveTransferredCaseReference(
+                AUTH_TOKEN, "Newcastle", "EMPLOYMENT", currentCaseId);
+    }
+
+    @Test
+    public void testCaseRefRetrievalRequest_Exception() throws Exception {
+        String errorMessage = "TEST Error Message";
+        String caseId = "44456";
+        when(ccdClient.retrieveTransferredCaseReference(any(), any(), any(), any()))
+                .thenThrow(new RuntimeException(errorMessage));
+
+        // Act & Assert
+        Exception exception = assertThrows(CaseCreationException.class, () -> {
+            caseRetrievalForCaseWorkerService.caseRefRetrievalRequest(AUTH_TOKEN, "Newcastle",
+                    "EMPLOYMENT", caseId);
+        });
+
+        String expectedMessage = MESSAGE + caseId + errorMessage;
+        assertTrue(exception.getMessage().contains(expectedMessage));
+        verify(ccdClient, times(1)).retrieveTransferredCaseReference(
+                AUTH_TOKEN, "Newcastle", "EMPLOYMENT", caseId);
     }
 
     @Test
     public void testTransferSourceCaseRetrievalESRequest() throws IOException {
         String currentCaseId = "123456";
-        String authToken = "authToken";
-
         SubmitEvent submitEvent = getSubmitEvent();
         when(ccdClient.retrieveTransferredCaseElasticSearch(any(), any(), any()))
                 .thenReturn(List.of(submitEvent));
         List<Pair<String, List<SubmitEvent>>> result =
                 caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
-                        currentCaseId, "Newcastle", authToken, List.of("Leeds"));
+                        currentCaseId, "Newcastle", AUTH_TOKEN, List.of("Leeds"));
 
         assertEquals(submitEvent, result.get(0).getSecond().get(0));
         assertEquals("Leeds", result.get(0).getFirst());
@@ -111,25 +152,23 @@ public class CaseRetrievalForCaseWorkerServiceTest {
     @Test
     public void testTransferSourceCaseRetrievalESRequest_When_CaseTypeIdsToCheck_Null() throws IOException {
         String currentCaseId = "123456";
-        String authToken = "authToken";
         SubmitEvent submitEvent = getSubmitEvent();
         when(ccdClient.retrieveTransferredCaseElasticSearch(any(), any(), any())).thenReturn(List.of(submitEvent));
         List<Pair<String, List<SubmitEvent>>> result =
                 caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
-                        currentCaseId, "Newcastle", authToken, new ArrayList<>());
+                        currentCaseId, "Newcastle", AUTH_TOKEN, new ArrayList<>());
         assertNotNull(result);
-        assertEquals(result.size(), 0);
+        assertEquals(0, result.size());
     }
 
     @Test(expected = Exception.class)
     public void testTransferSourceCaseRetrievalESRequestThrowsException() throws IOException {
         String currentCaseId = "123456";
-        String authToken = "authToken";
         SubmitEvent submitEvent = getSubmitEvent();
         when(ccdClient.retrieveTransferredCaseElasticSearch(any(), any(), any()))
                 .thenReturn(List.of(submitEvent));
         caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(currentCaseId,
-                "Newcastle", authToken, null);
+                "Newcastle", AUTH_TOKEN, null);
     }
 
     private SubmitEvent getSubmitEvent() {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseRetrievalForCaseWorkerServiceTest.java
@@ -150,6 +150,27 @@ public class CaseRetrievalForCaseWorkerServiceTest {
     }
 
     @Test
+    public void testTransferSourceCaseRetrievalESRequestContinue() throws IOException {
+        String currentCaseId = "123456";
+        SubmitEvent submitEvent = getSubmitEvent();
+        when(ccdClient.retrieveTransferredCaseElasticSearch(any(), any(), any()))
+                .thenReturn(List.of(submitEvent));
+        List<Pair<String, List<SubmitEvent>>> result =
+                caseRetrievalForCaseWorkerService.transferSourceCaseRetrievalESRequest(
+                        currentCaseId, "Newcastle", AUTH_TOKEN,
+                        List.of("Leeds", "Newcastle", "Manchester"));
+
+        assertEquals(submitEvent, result.get(0).getSecond().get(0));
+        assertEquals("Leeds", result.get(0).getFirst());
+        verify(ccdClient, times(0)).retrieveTransferredCaseElasticSearch(
+                AUTH_TOKEN, "Newcastle", currentCaseId);
+        verify(ccdClient, times(1)).retrieveTransferredCaseElasticSearch(
+                AUTH_TOKEN, "Leeds", currentCaseId);
+        verify(ccdClient, times(1)).retrieveTransferredCaseElasticSearch(
+                AUTH_TOKEN, "Manchester", currentCaseId);
+    }
+
+    @Test
     public void testTransferSourceCaseRetrievalESRequest_When_CaseTypeIdsToCheck_Null() throws IOException {
         String currentCaseId = "123456";
         SubmitEvent submitEvent = getSubmitEvent();


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RET-4892


### Change description ###
The refactoring implements case link update for cases where there is only two duplicates based on ethos reference initial search. Then, validation is made if the two cases are the same by comparing 5 field values as mentioned in the comments in the code.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
