### PR TITLE
Fix: Allow decimal values for negative hearing lengths in validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,6 @@ LABEL maintainer="https://github.com/hmcts/ethos-repl-docmosis-service"
 COPY lib/applicationinsights.json /opt/app/
 COPY build/libs/ethos-repl-docmosis-service.jar /opt/app/
 
-FROM debian:bookworm-20260406 AS builder
-
-USER root
-RUN apt update
-RUN apt install --yes libharfbuzz-dev
-USER hmcts
-
-FROM base
-
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0 /usr/lib/x86_64-linux-gnu/libharfbuzz.so.0
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgraphite2.so.3 /usr/lib/x86_64-linux-gnu/libgraphite2.so.3
-
 EXPOSE 8081
 
 CMD ["ethos-repl-docmosis-service.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -340,7 +340,7 @@ configurations.configureEach {
 
 dependencies {
 
-    implementation group: 'com.github.hmcts', name: 'et-shared', version: '1.0.91'
+    implementation group: 'com.github.hmcts', name: 'et-shared', version: '1.0.97'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
 
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.1'

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -614,7 +614,7 @@ public class CaseManagementForCaseWorkerService {
     private void addNegativeHearingLengthsError(HearingTypeItem hearingTypeItem, List<String> errors,
                                                 String hearingNumber) {
         try {
-            int parsed = Integer.parseInt(hearingTypeItem.getValue().getHearingEstLengthNum().trim());
+            double parsed = Double.parseDouble(hearingTypeItem.getValue().getHearingEstLengthNum().trim());
             if (parsed <= 0) {
                 errors.add(String.format(NEGATIVE_HEARING_LENGTH_MESSAGE, hearingNumber));
             }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -715,7 +715,8 @@ class CaseManagementForCaseWorkerServiceTest {
         "' 1 ', false",
         "'-1', true",
         "'0', true",
-        "'Test', true"
+        "'Test', true",
+        "'2.5', false"
     })
     void amendMidEventHearingEstLengthNum(String input, boolean expectError) {
         CaseData caseData = createCaseWithHearingDate("2022-03-18T23:59:00.000");


### PR DESCRIPTION
Fix: Allow decimal values for negative hearing lengths in validation